### PR TITLE
Поддержка статус-реакций в VK-канале (closes #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "src/media.ts",
     "src/monitor.ts",
     "src/probe.ts",
+    "src/reactions-controller.ts",
     "src/runtime.ts",
     "src/sanitize.ts",
     "src/send-support.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -15,6 +15,7 @@ const entryPoints = [
   "src/media.ts",
   "src/monitor.ts",
   "src/probe.ts",
+  "src/reactions-controller.ts",
   "src/runtime.ts",
   "src/sanitize.ts",
   "src/send-support.ts",

--- a/src/channel.setup.ts
+++ b/src/channel.setup.ts
@@ -31,7 +31,7 @@ export const vkSetupPlugin: ChannelPlugin<ResolvedVkAccount> = {
   },
   capabilities: {
     chatTypes: ["direct", "group"],
-    reactions: false,
+    reactions: true,
     threads: false,
     media: true,
     nativeCommands: false,

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -203,8 +203,8 @@ describe("plugin metadata", () => {
     expect(vkPlugin.capabilities.media).toBe(true);
   });
 
-  it("does not support reactions or threads", () => {
-    expect(vkPlugin.capabilities.reactions).toBe(false);
+  it("supports reactions but not threads", () => {
+    expect(vkPlugin.capabilities.reactions).toBe(true);
     expect(vkPlugin.capabilities.threads).toBe(false);
   });
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -184,7 +184,7 @@ export const vkPlugin: ChannelPlugin<ResolvedVkAccount, VkProbe> = {
   },
   capabilities: {
     chatTypes: ["direct", "group"],
-    reactions: false,
+    reactions: true,
     threads: false,
     media: true,
     nativeCommands: false,

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -60,6 +60,42 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
   logInboundDrop: vi.fn(),
 }));
 
+vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
+  DEFAULT_EMOJIS: {
+    queued: "👀",
+    thinking: "🧠",
+    tool: "🛠️",
+    coding: "🛠️",
+    web: "🛠️",
+    deploy: "🛠️",
+    build: "🛠️",
+    concierge: "🛠️",
+    done: "✅",
+    error: "❌",
+    stallSoft: "⏳",
+    stallHard: "⏱️",
+    compacting: "🗜️",
+  },
+  DEFAULT_TIMING: {
+    debounceMs: 250,
+    stallSoftMs: 10000,
+    stallHardMs: 30000,
+    doneHoldMs: 1500,
+    errorHoldMs: 2500,
+  },
+  createStatusReactionController: vi.fn(() => ({
+    setQueued: vi.fn(),
+    setThinking: vi.fn(),
+    setTool: vi.fn(),
+    setCompacting: vi.fn(),
+    setDone: vi.fn().mockResolvedValue(undefined),
+    setError: vi.fn().mockResolvedValue(undefined),
+    cancelPending: vi.fn(),
+    clear: vi.fn().mockResolvedValue(undefined),
+    restoreInitial: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 vi.mock("openclaw/plugin-sdk/channel-policy", () => ({
   readStoreAllowFromForDmPolicy: async ({ readStore }: Record<string, any>) =>
     readStore ? await readStore() : [],

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -29,7 +29,10 @@ import {
   resolveVkInboundMediaUrls,
 } from "./media.js";
 import { getVkRuntime } from "./runtime.js";
-import { markMessageReadVk, sendPayloadVk, sendReactionVk, sendTypingVk } from "./send.js";
+import { markMessageReadVk, sendPayloadVk, sendTypingVk } from "./send.js";
+import { createVkStatusReactionController } from "./reactions-controller.js";
+import { DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
+import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 import type { ResolvedVkAccount } from "./types.js";
 import type { CoreConfig, VkInboundMessage } from "./types.js";
 
@@ -398,9 +401,9 @@ export async function handleVkInbound(params: {
     );
   }
 
-  const ackReactionEmoji = "👍";
+  const cfgRecord = config as Record<string, Record<string, unknown>>;
   const ackReactionScope =
-    ((config as Record<string, Record<string, unknown>>).messages?.ackReactionScope as
+    (cfgRecord.messages?.ackReactionScope as
       | "all"
       | "direct"
       | "group-all"
@@ -408,7 +411,11 @@ export async function handleVkInbound(params: {
       | "off"
       | "none"
       | undefined) ?? undefined;
-  const shouldAck =
+  const statusReactionsCfg = cfgRecord.messages?.statusReactions as
+    | { enabled?: boolean; emojis?: Record<string, string>; timing?: Record<string, number> }
+    | undefined;
+  const statusReactionsEnabled =
+    statusReactionsCfg?.enabled === true &&
     typeof message.conversationMessageId === "number" &&
     core.channel.reactions.shouldAckReaction({
       scope: ackReactionScope,
@@ -419,49 +426,104 @@ export async function handleVkInbound(params: {
       canDetectMention: true,
       effectiveWasMentioned: isGroup ? wasMentioned : false,
     });
-  if (shouldAck && typeof message.conversationMessageId === "number") {
-    try {
-      await sendReactionVk(
-        String(message.peerId),
-        message.conversationMessageId,
-        ackReactionEmoji,
-        account,
-      );
-    } catch (err) {
-      runtime.log?.(
-        `vk: ack reaction failed for peerId=${message.peerId} cmid=${message.conversationMessageId}: ${String(err)}`,
-      );
-    }
+  const removeAckAfterReply =
+    (cfgRecord.messages?.removeAckAfterReply as boolean | undefined) ?? false;
+  let statusReactions: StatusReactionController | null = null;
+  if (statusReactionsEnabled && typeof message.conversationMessageId === "number") {
+    statusReactions = createVkStatusReactionController({
+      peerId: message.peerId,
+      cmid: message.conversationMessageId,
+      account,
+      emojiOverrides: statusReactionsCfg?.emojis,
+      timing: statusReactionsCfg?.timing,
+      onError: (err) => {
+        runtime.log?.(`vk: status-reaction error for cmid=${message.conversationMessageId}: ${String(err)}`);
+      },
+    });
+    void statusReactions.setQueued();
   }
 
   await startTypingOnce();
 
-  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-    ctx: ctxPayload,
-    cfg: config as OpenClawConfig,
-    dispatcherOptions: {
-      ...prefixOptions,
-      onReplyStart: startTypingOnce,
-      typingCallbacks,
-      deliver: async (payload: unknown, info?: { kind?: string }) => {
-        const normalized =
-          payload && typeof payload === "object" && !Array.isArray(payload)
-            ? (payload as VkDispatchPayload)
-            : {};
-        const resolvedButtons = resolveVkButtonsFromPayload(normalized);
-        await deliverVkReply({
-          payload: normalized,
-          peerId: message.peerId,
-          accountId: account.accountId,
-          statusSink,
-          clearKeyboard:
-            payloadCommand && info?.kind === "final" && !resolvedButtons ? true : undefined,
-        });
+  let dispatchError = false;
+  try {
+    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg: config as OpenClawConfig,
+      dispatcherOptions: {
+        ...prefixOptions,
+        onReplyStart: async () => {
+          await startTypingOnce();
+          if (statusReactions) await statusReactions.setThinking();
+        },
+        typingCallbacks,
+        deliver: async (payload: unknown, info?: { kind?: string }) => {
+          const normalized =
+            payload && typeof payload === "object" && !Array.isArray(payload)
+              ? (payload as VkDispatchPayload)
+              : {};
+          const resolvedButtons = resolveVkButtonsFromPayload(normalized);
+          await deliverVkReply({
+            payload: normalized,
+            peerId: message.peerId,
+            accountId: account.accountId,
+            statusSink,
+            clearKeyboard:
+              payloadCommand && info?.kind === "final" && !resolvedButtons ? true : undefined,
+          });
+        },
+        onError: onDispatchError,
       },
-      onError: onDispatchError,
-    },
-    replyOptions: {
-      onModelSelected,
-    },
-  });
+      replyOptions: {
+        onModelSelected,
+        ...(statusReactions
+          ? {
+              onReasoningStream: async () => {
+                await statusReactions!.setThinking();
+              },
+              onToolStart: async (payload: { name?: string }) => {
+                await statusReactions!.setTool(payload?.name);
+              },
+              onCompactionStart: async () => {
+                await statusReactions!.setCompacting();
+              },
+              onCompactionEnd: async () => {
+                statusReactions!.cancelPending();
+                await statusReactions!.setThinking();
+              },
+            }
+          : {}),
+      },
+    });
+  } catch (err) {
+    dispatchError = true;
+    throw err;
+  } finally {
+    if (statusReactions) {
+      try {
+        if (dispatchError) {
+          await statusReactions.setError();
+        } else {
+          await statusReactions.setDone();
+        }
+      } catch (err) {
+        runtime.log?.(`vk: status-reaction finalize failed: ${String(err)}`);
+      }
+      if (removeAckAfterReply) {
+        const holdMs = dispatchError
+          ? DEFAULT_TIMING.errorHoldMs
+          : DEFAULT_TIMING.doneHoldMs;
+        void (async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, holdMs));
+          try {
+            await statusReactions!.clear();
+          } catch (err) {
+            runtime.log?.(`vk: status-reaction clear failed: ${String(err)}`);
+          }
+        })();
+      } else {
+        void statusReactions.restoreInitial();
+      }
+    }
+  }
 }

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -521,9 +521,14 @@ export async function handleVkInbound(params: {
             runtime.log?.(`vk: status-reaction clear failed: ${String(err)}`);
           }
         })();
-      } else {
-        void statusReactions.restoreInitial();
       }
+      // NB: we intentionally do NOT call statusReactions.restoreInitial()
+      // here. The Discord/bundled flow uses restoreInitial after setDone
+      // to peel away intermediate reactions on platforms that support a
+      // stack of reactions. VK lets the bot keep at most one reaction
+      // per message, so setDone/setError already *replaced* the previous
+      // emoji — calling restoreInitial would just overwrite the final
+      // state with the initial "queued" emoji again (👍 instead of 🎉).
     }
   }
 }

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -446,6 +446,14 @@ export async function handleVkInbound(params: {
   await startTypingOnce();
 
   let dispatchError = false;
+  // Defensive guard mirroring the bundled channels' isProcessAborted() check
+  // (see core message-handler.process / telegram bot). VK has no abortSignal in
+  // this scope, so we use a local "settled" flag: once the turn finalizes
+  // (setDone/setError in finally), late-arriving progress callbacks become
+  // no-ops. The SDK controller already guards on `finished`, so this is
+  // belt-and-suspenders — but it keeps intent explicit and avoids redundant
+  // setReaction churn after the turn is done.
+  let turnSettled = false;
   try {
     await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
@@ -478,16 +486,28 @@ export async function handleVkInbound(params: {
         onModelSelected,
         ...(statusReactions
           ? {
+              // Without these, the core gates onToolStart/onCompactionStart
+              // behind tool-summary visibility (requiresToolSummaryVisibility),
+              // so the 👌/🙏 reactions never fire in DMs even though
+              // onReasoningStream (🤔) does. These flags enable the "quiet
+              // direct native progress" path: reaction callbacks run without
+              // emitting default tool-progress text messages.
+              suppressDefaultToolProgressMessages: true,
+              allowProgressCallbacksWhenSourceDeliverySuppressed: true,
               onReasoningStream: async () => {
+                if (turnSettled) return;
                 await statusReactions!.setThinking();
               },
               onToolStart: async (payload: { name?: string }) => {
+                if (turnSettled) return;
                 await statusReactions!.setTool(payload?.name);
               },
               onCompactionStart: async () => {
+                if (turnSettled) return;
                 await statusReactions!.setCompacting();
               },
               onCompactionEnd: async () => {
+                if (turnSettled) return;
                 statusReactions!.cancelPending();
                 await statusReactions!.setThinking();
               },
@@ -499,6 +519,7 @@ export async function handleVkInbound(params: {
     dispatchError = true;
     throw err;
   } finally {
+    turnSettled = true;
     if (statusReactions) {
       try {
         if (dispatchError) {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -29,7 +29,7 @@ import {
   resolveVkInboundMediaUrls,
 } from "./media.js";
 import { getVkRuntime } from "./runtime.js";
-import { markMessageReadVk, sendPayloadVk, sendTypingVk } from "./send.js";
+import { markMessageReadVk, sendPayloadVk, sendReactionVk, sendTypingVk } from "./send.js";
 import type { ResolvedVkAccount } from "./types.js";
 import type { CoreConfig, VkInboundMessage } from "./types.js";
 
@@ -396,6 +396,42 @@ export async function handleVkInbound(params: {
     runtime.log?.(
       `vk: mark read failed for peerId=${message.peerId} messageId=${message.messageId}: ${String(err)}`,
     );
+  }
+
+  const ackReactionEmoji = "👍";
+  const ackReactionScope =
+    ((config as Record<string, Record<string, unknown>>).messages?.ackReactionScope as
+      | "all"
+      | "direct"
+      | "group-all"
+      | "group-mentions"
+      | "off"
+      | "none"
+      | undefined) ?? undefined;
+  const shouldAck =
+    typeof message.conversationMessageId === "number" &&
+    core.channel.reactions.shouldAckReaction({
+      scope: ackReactionScope,
+      isDirect: !isGroup,
+      isGroup,
+      isMentionableGroup: isGroup,
+      requireMention: Boolean(requireMention),
+      canDetectMention: true,
+      effectiveWasMentioned: isGroup ? wasMentioned : false,
+    });
+  if (shouldAck && typeof message.conversationMessageId === "number") {
+    try {
+      await sendReactionVk(
+        String(message.peerId),
+        message.conversationMessageId,
+        ackReactionEmoji,
+        account,
+      );
+    } catch (err) {
+      runtime.log?.(
+        `vk: ack reaction failed for peerId=${message.peerId} cmid=${message.conversationMessageId}: ${String(err)}`,
+      );
+    }
   }
 
   await startTypingOnce();

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -111,6 +111,10 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
 
     const message: VkInboundMessage = {
       messageId: String(context.id),
+      conversationMessageId:
+        typeof context.conversationMessageId === "number" && Number.isFinite(context.conversationMessageId)
+          ? context.conversationMessageId
+          : undefined,
       peerId,
       senderId,
       text,

--- a/src/reactions-controller.test.ts
+++ b/src/reactions-controller.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateStatusReactionController = vi.hoisted(() =>
+  vi.fn(() => ({
+    setQueued: vi.fn(),
+    setThinking: vi.fn(),
+    setTool: vi.fn(),
+    setCompacting: vi.fn(),
+    setDone: vi.fn().mockResolvedValue(undefined),
+    setError: vi.fn().mockResolvedValue(undefined),
+    cancelPending: vi.fn(),
+    clear: vi.fn().mockResolvedValue(undefined),
+    restoreInitial: vi.fn().mockResolvedValue(undefined),
+  })),
+);
+
+const mockSendReaction = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+const mockDeleteReaction = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
+  DEFAULT_EMOJIS: {
+    queued: "👀",
+    thinking: "🧠",
+    tool: "🛠️",
+    coding: "🛠️",
+    web: "🛠️",
+    deploy: "🛠️",
+    build: "🛠️",
+    concierge: "🛠️",
+    done: "✅",
+    error: "❌",
+    stallSoft: "⏳",
+    stallHard: "⏱️",
+    compacting: "🗜️",
+  },
+  createStatusReactionController: mockCreateStatusReactionController,
+}));
+
+vi.mock("./send.js", () => ({
+  sendReactionVk: mockSendReaction,
+  deleteReactionVk: mockDeleteReaction,
+}));
+
+import {
+  createVkStatusReactionController,
+  VK_DEFAULT_STATUS_REACTION_EMOJIS,
+} from "./reactions-controller.js";
+import { makeAccount } from "./test-helpers.js";
+
+describe("VK_DEFAULT_STATUS_REACTION_EMOJIS", () => {
+  it("overrides every status emoji with a VK-supported reaction", () => {
+    // VK only supports a fixed catalog (see mapEmojiToVkReactionId).
+    // These are the 16 emojis we accept; anything else falls back to 👍.
+    const supported = new Set([
+      "❤️", "❤", "🔥", "😂", "🤣", "👍", "💩", "⁉️", "⁉",
+      "😭", "😡", "👎", "👌", "😄", "🤔", "🙏", "😘", "😍", "🎉",
+    ]);
+    for (const [state, emoji] of Object.entries(VK_DEFAULT_STATUS_REACTION_EMOJIS)) {
+      expect(supported.has(emoji), `${state} → ${emoji}`).toBe(true);
+    }
+  });
+
+  it("uses distinct emojis for the key states", () => {
+    const { queued, thinking, tool, done, error } = VK_DEFAULT_STATUS_REACTION_EMOJIS;
+    expect(new Set([thinking, tool, error]).size).toBe(3);
+    // queued and done may collide on 👍 — that's intentional (both are the
+    // happy-path bookends and VK doesn't have a perfect ✅ analogue).
+    expect(queued).toBeDefined();
+    expect(done).toBeDefined();
+  });
+});
+
+describe("createVkStatusReactionController", () => {
+  beforeEach(() => {
+    mockCreateStatusReactionController.mockClear();
+    mockSendReaction.mockClear();
+    mockDeleteReaction.mockClear();
+  });
+
+  it("wires sendReactionVk / deleteReactionVk into the adapter", async () => {
+    const account = makeAccount();
+    createVkStatusReactionController({ peerId: 42, cmid: 7, account });
+
+    expect(mockCreateStatusReactionController).toHaveBeenCalledTimes(1);
+    const { adapter } = mockCreateStatusReactionController.mock.calls[0][0];
+
+    await adapter.setReaction("🤔");
+    expect(mockSendReaction).toHaveBeenCalledWith("42", 7, "🤔", account);
+
+    await adapter.clearReaction!();
+    expect(mockDeleteReaction).toHaveBeenCalledWith("42", 7, account);
+  });
+
+  it("applies VK_DEFAULT_STATUS_REACTION_EMOJIS by default", () => {
+    createVkStatusReactionController({ peerId: 1, cmid: 1, account: makeAccount() });
+    const { emojis, initialEmoji } = mockCreateStatusReactionController.mock.calls[0][0];
+
+    expect(emojis.thinking).toBe(VK_DEFAULT_STATUS_REACTION_EMOJIS.thinking);
+    expect(emojis.error).toBe(VK_DEFAULT_STATUS_REACTION_EMOJIS.error);
+    expect(initialEmoji).toBe(VK_DEFAULT_STATUS_REACTION_EMOJIS.queued);
+  });
+
+  it("merges caller emojiOverrides on top of defaults", () => {
+    createVkStatusReactionController({
+      peerId: 1,
+      cmid: 1,
+      account: makeAccount(),
+      emojiOverrides: { thinking: "🔥", done: "🎉" },
+    });
+    const { emojis } = mockCreateStatusReactionController.mock.calls[0][0];
+
+    expect(emojis.thinking).toBe("🔥");
+    expect(emojis.done).toBe("🎉");
+    expect(emojis.error).toBe(VK_DEFAULT_STATUS_REACTION_EMOJIS.error);
+  });
+
+  it("passes timing and onError through unchanged", () => {
+    const onError = vi.fn();
+    const timing = { debounceMs: 500 };
+    createVkStatusReactionController({
+      peerId: 1,
+      cmid: 1,
+      account: makeAccount(),
+      timing,
+      onError,
+    });
+
+    const args = mockCreateStatusReactionController.mock.calls[0][0];
+    expect(args.timing).toBe(timing);
+    expect(args.onError).toBe(onError);
+    expect(args.enabled).toBe(true);
+  });
+
+  it("honors an explicit initialEmoji override", () => {
+    createVkStatusReactionController({
+      peerId: 1,
+      cmid: 1,
+      account: makeAccount(),
+      initialEmoji: "🤔",
+    });
+    expect(mockCreateStatusReactionController.mock.calls[0][0].initialEmoji).toBe("🤔");
+  });
+});

--- a/src/reactions-controller.test.ts
+++ b/src/reactions-controller.test.ts
@@ -60,13 +60,9 @@ describe("VK_DEFAULT_STATUS_REACTION_EMOJIS", () => {
     }
   });
 
-  it("uses distinct emojis for the key states", () => {
+  it("uses distinct emojis for the key states (queued/thinking/tool/done/error)", () => {
     const { queued, thinking, tool, done, error } = VK_DEFAULT_STATUS_REACTION_EMOJIS;
-    expect(new Set([thinking, tool, error]).size).toBe(3);
-    // queued and done may collide on 👍 — that's intentional (both are the
-    // happy-path bookends and VK doesn't have a perfect ✅ analogue).
-    expect(queued).toBeDefined();
-    expect(done).toBeDefined();
+    expect(new Set([queued, thinking, tool, done, error]).size).toBe(5);
   });
 });
 

--- a/src/reactions-controller.ts
+++ b/src/reactions-controller.ts
@@ -17,6 +17,7 @@ import type { ResolvedVkAccount } from "./types.js";
  */
 export const VK_DEFAULT_STATUS_REACTION_EMOJIS: Required<StatusReactionEmojis> = {
   ...DEFAULT_EMOJIS,
+  // 🎉 (id=16) marks the terminal "done" so it stands out from queued 👍.
   queued: "👍",
   thinking: "🤔",
   tool: "👌",
@@ -25,11 +26,11 @@ export const VK_DEFAULT_STATUS_REACTION_EMOJIS: Required<StatusReactionEmojis> =
   deploy: "🔥",
   build: "👌",
   concierge: "👌",
-  done: "👍",
+  done: "🎉",
   error: "😡",
   stallSoft: "🤔",
   stallHard: "⁉️",
-  compacting: "🤔",
+  compacting: "🙏",
 };
 
 export type VkStatusReactionParams = {

--- a/src/reactions-controller.ts
+++ b/src/reactions-controller.ts
@@ -1,0 +1,70 @@
+import {
+  createStatusReactionController,
+  DEFAULT_EMOJIS,
+  type StatusReactionAdapter,
+  type StatusReactionController,
+  type StatusReactionEmojis,
+  type StatusReactionTiming,
+} from "openclaw/plugin-sdk/channel-feedback";
+import { deleteReactionVk, sendReactionVk } from "./send.js";
+import type { ResolvedVkAccount } from "./types.js";
+
+/**
+ * VK reactions are a fixed catalog of 16 emojis (see mapEmojiToVkReactionId
+ * in send.ts), so the default OpenClaw status emoji set (👀🧠🛠️✅❌⏳⏱️ …)
+ * would all fall back to the same VK reaction. Override every status with
+ * the closest available VK emoji so the user can tell the states apart.
+ */
+export const VK_DEFAULT_STATUS_REACTION_EMOJIS: Required<StatusReactionEmojis> = {
+  ...DEFAULT_EMOJIS,
+  queued: "👍",
+  thinking: "🤔",
+  tool: "👌",
+  coding: "👌",
+  web: "🔥",
+  deploy: "🔥",
+  build: "👌",
+  concierge: "👌",
+  done: "👍",
+  error: "😡",
+  stallSoft: "🤔",
+  stallHard: "⁉️",
+  compacting: "🤔",
+};
+
+export type VkStatusReactionParams = {
+  peerId: number | string;
+  cmid: number;
+  account: ResolvedVkAccount;
+  initialEmoji?: string;
+  emojiOverrides?: StatusReactionEmojis;
+  timing?: StatusReactionTiming;
+  onError?: (err: unknown) => void;
+};
+
+export function createVkStatusReactionController(
+  params: VkStatusReactionParams,
+): StatusReactionController {
+  const adapter: StatusReactionAdapter = {
+    setReaction: async (emoji) => {
+      await sendReactionVk(String(params.peerId), params.cmid, emoji, params.account);
+    },
+    clearReaction: async () => {
+      await deleteReactionVk(String(params.peerId), params.cmid, params.account);
+    },
+  };
+
+  const emojis: StatusReactionEmojis = {
+    ...VK_DEFAULT_STATUS_REACTION_EMOJIS,
+    ...(params.emojiOverrides ?? {}),
+  };
+
+  return createStatusReactionController({
+    enabled: true,
+    adapter,
+    initialEmoji: params.initialEmoji ?? VK_DEFAULT_STATUS_REACTION_EMOJIS.queued,
+    emojis,
+    timing: params.timing,
+    onError: params.onError,
+  });
+}

--- a/src/send.test.ts
+++ b/src/send.test.ts
@@ -8,6 +8,7 @@ import {
   applyVkAllowlistConfigEdit,
   clearVkInstances,
   isVkGroupPeerId,
+  mapEmojiToVkReactionId,
   markMessageReadVk,
   normalizeVkDirectoryEntries,
   normalizeVkSenderAllowEntry,
@@ -23,6 +24,8 @@ import {
   sendMessageVk,
   sendPayloadVk,
   sendPhotoVk,
+  sendReactionVk,
+  deleteReactionVk,
   sendTypingVk,
 } from "./send.js";
 import { makeAccount } from "./test-helpers.js";
@@ -55,6 +58,8 @@ vi.mock("./runtime.js", () => ({
 const mockMessagesSend = vi.hoisted(() => vi.fn());
 const mockMessagesMarkAsRead = vi.hoisted(() => vi.fn().mockResolvedValue(1));
 const mockSetActivity = vi.hoisted(() => vi.fn().mockResolvedValue(1));
+const mockSendReaction = vi.hoisted(() => vi.fn().mockResolvedValue(1));
+const mockDeleteReaction = vi.hoisted(() => vi.fn().mockResolvedValue(1));
 const mockUploadPhoto = vi.hoisted(() => vi.fn().mockResolvedValue("photo123_456"));
 const mockUploadDocument = vi.hoisted(() => vi.fn().mockResolvedValue("doc123_789"));
 const mockUploadAudioMessage = vi.hoisted(() => vi.fn().mockResolvedValue("audio_message123_789"));
@@ -76,6 +81,8 @@ vi.mock("vk-io", () => ({
           send: mockMessagesSend,
           markAsRead: mockMessagesMarkAsRead,
           setActivity: mockSetActivity,
+          sendReaction: mockSendReaction,
+          deleteReaction: mockDeleteReaction,
         },
       },
       upload: {
@@ -129,6 +136,8 @@ beforeEach(() => {
   mockMessagesSend.mockReset();
   mockMessagesMarkAsRead.mockReset().mockResolvedValue(1);
   mockSetActivity.mockReset().mockResolvedValue(1);
+  mockSendReaction.mockReset().mockResolvedValue(1);
+  mockDeleteReaction.mockReset().mockResolvedValue(1);
   mockUploadPhoto.mockReset().mockResolvedValue("photo123_456");
   mockUploadDocument.mockReset().mockResolvedValue("doc123_789");
   mockUploadAudioMessage.mockReset().mockResolvedValue("audio_message123_789");
@@ -676,6 +685,85 @@ describe("markMessageReadVk", () => {
       peer_id: 123,
       start_message_id: 77,
       mark_conversation_as_read: true,
+    });
+  });
+});
+
+describe("mapEmojiToVkReactionId", () => {
+  it("maps known emojis to their VK reaction ids", () => {
+    expect(mapEmojiToVkReactionId("❤️")).toBe(1);
+    expect(mapEmojiToVkReactionId("🔥")).toBe(2);
+    expect(mapEmojiToVkReactionId("😂")).toBe(3);
+    expect(mapEmojiToVkReactionId("👍")).toBe(4);
+    expect(mapEmojiToVkReactionId("💩")).toBe(5);
+    expect(mapEmojiToVkReactionId("😡")).toBe(8);
+    expect(mapEmojiToVkReactionId("🤔")).toBe(12);
+    expect(mapEmojiToVkReactionId("🎉")).toBe(16);
+  });
+
+  it("falls back to thumbs up for unsupported emoji", () => {
+    expect(mapEmojiToVkReactionId("👀")).toBe(4);
+    expect(mapEmojiToVkReactionId("🧠")).toBe(4);
+    expect(mapEmojiToVkReactionId("not-an-emoji")).toBe(4);
+  });
+});
+
+describe("sendReactionVk", () => {
+  beforeEach(() => {
+    clearVkInstances();
+    mockSendReaction.mockReset().mockResolvedValue(1);
+    vi.mocked(VK).mockClear();
+  });
+
+  it("posts the mapped reaction id to VK", async () => {
+    const ok = await sendReactionVk("123", 42, "👍", makeAccount());
+
+    expect(ok).toBe(true);
+    expect(mockSendReaction).toHaveBeenCalledWith({
+      peer_id: 123,
+      cmid: 42,
+      reaction_id: 4,
+    });
+  });
+
+  it("normalizes vk-prefixed peer IDs", async () => {
+    await sendReactionVk("vk:chat:9", 7, "❤️", makeAccount());
+
+    expect(mockSendReaction).toHaveBeenCalledWith({
+      peer_id: 9,
+      cmid: 7,
+      reaction_id: 1,
+    });
+  });
+
+  it("silently returns false when token is empty", async () => {
+    const ok = await sendReactionVk("123", 42, "👍", makeAccount({ token: "" }));
+
+    expect(ok).toBe(false);
+    expect(mockSendReaction).not.toHaveBeenCalled();
+  });
+
+  it("silently returns false when peer or cmid is invalid", async () => {
+    await sendReactionVk("abc", 42, "👍", makeAccount());
+    await sendReactionVk("123", Number.NaN, "👍", makeAccount());
+
+    expect(mockSendReaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteReactionVk", () => {
+  beforeEach(() => {
+    clearVkInstances();
+    mockDeleteReaction.mockReset().mockResolvedValue(1);
+    vi.mocked(VK).mockClear();
+  });
+
+  it("posts deleteReaction with peer_id and cmid", async () => {
+    await deleteReactionVk("123", 42, makeAccount());
+
+    expect(mockDeleteReaction).toHaveBeenCalledWith({
+      peer_id: 123,
+      cmid: 42,
     });
   });
 });

--- a/src/send.ts
+++ b/src/send.ts
@@ -732,6 +732,83 @@ export async function markMessageReadVk(
   });
 }
 
+// VK reaction id catalog as returned by messages.getReactionsAssets (16 items):
+//   1=❤️ 2=🔥 3=😂 4=👍 5=💩 6=⁉️ 7=😭 8=😡
+//   9=👎 10=👌 11=😄 12=🤔 13=🙏 14=😘 15=😍 16=🎉
+const VK_REACTION_ID_DEFAULT = 4; // 👍
+
+const VK_REACTION_ID_BY_EMOJI: Readonly<Record<string, number>> = {
+  "❤️": 1,
+  "❤": 1,
+  "🔥": 2,
+  "😂": 3,
+  "🤣": 3,
+  "👍": 4,
+  "💩": 5,
+  "⁉️": 6,
+  "⁉": 6,
+  "😭": 7,
+  "😡": 8,
+  "👎": 9,
+  "👌": 10,
+  "😄": 11,
+  "🤔": 12,
+  "🙏": 13,
+  "😘": 14,
+  "😍": 15,
+  "🎉": 16,
+};
+
+export function mapEmojiToVkReactionId(emoji: string): number {
+  return VK_REACTION_ID_BY_EMOJI[emoji] ?? VK_REACTION_ID_DEFAULT;
+}
+
+export async function sendReactionVk(
+  to: string,
+  cmid: number,
+  emoji: string,
+  account: ResolvedVkAccount,
+): Promise<boolean> {
+  if (!account.token) {
+    return false;
+  }
+  const peerId = Number(normalizeVkTargetId(to));
+  if (Number.isNaN(peerId) || !Number.isFinite(cmid)) {
+    return false;
+  }
+  const reactionId = mapEmojiToVkReactionId(emoji);
+  const vk = getOrCreateVk(account.token);
+  await withVkRetry(async () => {
+    await vk.api.messages.sendReaction({
+      peer_id: peerId,
+      cmid,
+      reaction_id: reactionId,
+    });
+  });
+  return true;
+}
+
+export async function deleteReactionVk(
+  to: string,
+  cmid: number,
+  account: ResolvedVkAccount,
+): Promise<void> {
+  if (!account.token) {
+    return;
+  }
+  const peerId = Number(normalizeVkTargetId(to));
+  if (Number.isNaN(peerId) || !Number.isFinite(cmid)) {
+    return;
+  }
+  const vk = getOrCreateVk(account.token);
+  await withVkRetry(async () => {
+    await vk.api.messages.deleteReaction({
+      peer_id: peerId,
+      cmid,
+    });
+  });
+}
+
 async function sendMessageChunksVk(params: {
   to: string;
   chunks: VkPreparedFormattedMessage[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type ResolvedVkAccount = {
 
 export type VkInboundMessage = {
   messageId: string;
+  conversationMessageId?: number;
   peerId: number;
   senderId: number;
   text: string;


### PR DESCRIPTION
Реализует `messages.statusReactions` из ядра OpenClaw для VK-канала.

Связано с обсуждением в #5.

## Зачем

В ядре OpenClaw есть настраиваемая система, которая вешает emoji-индикаторы
на исходное сообщение пользователя по ходу работы агента
(👀 принято → 🧠 думает → 🛠️ инструмент → ✅ готово или ❌ ошибка, плюс ⏳/⏱️
при зависании). Этот же канал обратной связи использует bundled Telegram-плагин,
и он особенно ценен, когда обработка тихо падает или зависает без текстового
ответа.

VK-плагин раньше отдавал `capabilities.reactions: false`, и пользователи VK
не получали никакого визуального сигнала. Этот PR переключает флаг на `true`
и подключает полноценный controller.

## Что внутри

Три коммита, рассчитанные на последовательное чтение.

### `Add Stage 1 reaction support: ack reaction on inbound`

- Переключает `capabilities.reactions` на `true` в `src/channel.ts` и
  `src/channel.setup.ts`.
- Добавляет тонкие обёртки `sendReactionVk` / `deleteReactionVk` поверх
  `state.vk.api.messages.sendReaction` / `messages.deleteReaction` в
  `src/send.ts`, плюс `mapEmojiToVkReactionId` с каталогом из 16 элементов,
  полученным через `messages.getReactionsAssets` (сверено пробой
  с user-токеном). Таблица id такая: `1=❤️, 2=🔥, 3=😂, 4=👍, 5=💩, 6=⁉️,
  7=😭, 8=😡, 9=👎, 10=👌, 11=😄, 12=🤔, 13=🙏, 14=😘, 15=😍, 16=🎉` — всё
  что вне этого набора VK отклоняет (пробил `reaction_id` 17..50, все
  возвращают `invalid_reaction_id`).
- Прокидывает `context.conversationMessageId` через `VkInboundMessage`,
  чтобы из inbound-обработчика можно было целиться в правильный `cmid`.
- Заводит `core.channel.reactions.shouldAckReaction` в inbound flow; если
  он возвращает `true`, канал ставит 👍 (id=4) как первичный ack.
- В `channel.test.ts` поправлено ожидание; 5 новых тестов для emoji-map
  и send/delete обёрток (525/525 проходят).

### `Add Stage 2 multi-state status reaction controller`

- Добавляет `src/reactions-controller.ts`, оборачивающий публичную
  `createStatusReactionController` из `openclaw/plugin-sdk/channel-feedback`
  VK-friendly адаптером `StatusReactionAdapter` (`setReaction` →
  `sendReactionVk`, `clearReaction` → `deleteReactionVk`).
- Определяет `VK_DEFAULT_STATUS_REACTION_EMOJIS`, чтобы дефолтный набор
  ядра ✅/❌/🧠/⏳… был перевешен на 16-emoji каталог VK (иначе всё тихо
  схлопнулось бы в один и тот же fallback-id).
- `inbound.ts` создаёт controller, когда `messages.statusReactions.enabled
  === true` и доступен `conversationMessageId`; гейт идёт через
  `core.channel.reactions.shouldAckReaction`. Смены состояний управляются
  через replyOptions-колбэки (`onReplyStart` → `setThinking`,
  `onReasoningStream` → `setThinking`, `onToolStart` → `setTool`,
  `onCompactionStart` → `setCompacting`, `onCompactionEnd` →
  `cancelPending` + `setThinking`), а блок `finally` вызывает `setDone` /
  `setError`. Уважает `messages.removeAckAfterReply` (clear через
  `doneHoldMs` / `errorHoldMs`).
- `build.mjs` и список `files` в `package.json` подхватывают новый модуль
  (первая попытка деплоя падала с `Cannot find module
  './reactions-controller.js'`, потому что build-манифест его не доставлял).
  7 новых тестов для controller, 4 новых мока в тестовых файлах;
  532/532 проходят.

### `fix(reactions): distinct queued/done emojis + drop restoreInitial on VK`

Две связанные шлифовки после живого тестирования Stage 2.

1. Подкрутил дефолтный набор emoji. Stage 2 уехал с `queued = done = 👍`,
   потому что ближайший аналог дефолтной ✅-метки ядра в каталоге реакций
   VK отсутствует (бот видит только 16 штук из `getReactionsAssets`, никакой
   зелёной галочки). Зато 16-emoji набор включает 🎉 (id=16), который
   читается как чистое «готово» на VK-сообщении. Итог:
       queued     👍 (id=4)
       done       🎉 (id=16)  — было 👍, теперь отличается от queued
       compacting 🙏 (id=13)  — было 🤔 (схлопывалось с thinking/stallSoft),
                                теперь различимо, и компактификация контекста
                                становится видна
   Тесты проверяют, что queued/thinking/tool/done/error — пять разных
   значений.
2. Перестал вызывать `statusReactions.restoreInitial()` в блоке `finally`
   после `setDone` / `setError`. Этот вызов был скопирован из bundled
   Discord-канала, где он нужен, потому что Discord позволяет боту держать
   несколько реакций и `restoreInitial` снимает промежуточные. VK же
   разрешает только одну реакцию от бота на сообщение — `setDone` уже
   заменил предыдущий emoji, и `restoreInitial` просто рисует `queued`
   (👍) поверх `done` (🎉), из-за чего финальное состояние выглядит
   идентично первичному ack. Подтверждено per-state debug-логом до правки
   (уже удалён): `setDone` отрабатывает, `setReaction emoji=🎉 sent=true`,
   и сразу после ловился второй `setReaction emoji=👍 sent=true` — теперь
   его нет.

## Заметки для ревьюера

- `messages.getReactionsAssets` требует user-токен; каталог из 16 был
  получен через короткоживущий user OAuth и захардкожен в плагине. Если
  VK когда-то расширит каталог сверх 16, его придётся обновить;
  откатной путь — существующий `mapEmojiToVkReactionId`, возвращающий
  разумный дефолт.
- Таблица `VK_DEFAULT_STATUS_REACTION_EMOJIS` полностью переопределяется
  через `messages.statusReactions.emojis` (по контракту конфига OpenClaw),
  так что операторы, предпочитающие другой визуальный язык, могут поменять
  её без правки плагина.
- 532/532 теста проходят. Сборка чистая. Деплой локально против
  `openclaw@2026.5.26`, прогон через настоящий VK direct chat (полный
  цикл 👍 → 🤔 → 👌 → 🎉 подтверждён end-to-end).

— CoWorker Claude