### PR TITLE
fix: preserve VK location-only inbound messages

### DIFF
--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { describe, expect, it, beforeAll, beforeEach, afterAll, vi } from "vitest";
 import {
   extractVkInboundAttachments,
+  formatVkInboundGeoText,
   loadVkOutboundMedia,
   resolveVkInboundBodyText,
+  resolveVkInboundGeo,
   resolveVkInboundResolvedMedia,
   resolveVkInboundResolvedMediaPaths,
   resolveVkInboundResolvedMediaTypes,
@@ -286,6 +288,81 @@ describe("extractVkInboundAttachments", () => {
     expect(result[0].kind).toBe("image");
     expect(result[1].kind).toBe("document");
     expect(result[2].kind).toBe("audio");
+  });
+});
+
+describe("resolveVkInboundGeo", () => {
+  it("parses coordinates objects from VK geo payloads", () => {
+    expect(
+      resolveVkInboundGeo({
+        coordinates: {
+          latitude: 55.916704,
+          longitude: 37.815848,
+        },
+        place: {
+          title: "Королёв",
+          city: "Россия",
+        },
+      }),
+    ).toEqual({
+      latitude: 55.916704,
+      longitude: 37.815848,
+      placeTitle: "Королёв",
+      city: "Россия",
+    });
+  });
+
+  it('parses string coordinates in VK "lon lat" format', () => {
+    expect(
+      resolveVkInboundGeo({
+        coordinates: "37.815848 55.916704",
+      }),
+    ).toEqual({
+      latitude: 55.916704,
+      longitude: 37.815848,
+      placeTitle: undefined,
+      city: undefined,
+    });
+  });
+});
+
+describe("formatVkInboundGeoText", () => {
+  it("renders geo text with place details", () => {
+    expect(
+      formatVkInboundGeoText({
+        latitude: 55.916704,
+        longitude: 37.815848,
+        placeTitle: "Королёв",
+        city: "Россия",
+      }),
+    ).toBe("[VK location] 55.916704, 37.815848 (Королёв, Россия)");
+  });
+});
+
+describe("resolveVkInboundBodyText", () => {
+  it("returns geo text when message contains only location", () => {
+    expect(
+      resolveVkInboundBodyText({
+        geo: {
+          latitude: 55.916704,
+          longitude: 37.815848,
+          placeTitle: "Королёв",
+          city: "Россия",
+        },
+      }),
+    ).toBe("[VK location] 55.916704, 37.815848 (Королёв, Россия)");
+  });
+
+  it("appends geo text below regular text", () => {
+    expect(
+      resolveVkInboundBodyText({
+        text: "Проба",
+        geo: {
+          latitude: 55.916704,
+          longitude: 37.815848,
+        },
+      }),
+    ).toBe("Проба\n\n[VK location] 55.916704, 37.815848");
   });
 });
 

--- a/src/media.ts
+++ b/src/media.ts
@@ -2,7 +2,7 @@ import { readFile, realpath } from "node:fs/promises";
 import { basename, extname, isAbsolute, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
-import type { VkInboundAttachment, VkInboundResolvedMedia } from "./types.js";
+import type { VkInboundAttachment, VkInboundGeo, VkInboundResolvedMedia } from "./types.js";
 
 const IMAGE_EXTENSIONS = new Set([
   ".apng",
@@ -448,6 +448,80 @@ export function resolveVkInboundReplyContext(replyMessage: unknown): {
   };
 }
 
+export function resolveVkInboundGeo(rawGeo: unknown): VkInboundGeo | undefined {
+  if (!rawGeo || typeof rawGeo !== "object" || Array.isArray(rawGeo)) {
+    return undefined;
+  }
+
+  const record = rawGeo as Record<string, unknown>;
+  const coordinates = record.coordinates;
+
+  let latitude: number | undefined;
+  let longitude: number | undefined;
+
+  if (coordinates && typeof coordinates === "object" && !Array.isArray(coordinates)) {
+    const coordinateRecord = coordinates as Record<string, unknown>;
+    latitude =
+      typeof coordinateRecord.latitude === "number" && Number.isFinite(coordinateRecord.latitude)
+        ? coordinateRecord.latitude
+        : undefined;
+    longitude =
+      typeof coordinateRecord.longitude === "number" && Number.isFinite(coordinateRecord.longitude)
+        ? coordinateRecord.longitude
+        : undefined;
+  } else if (typeof coordinates === "string" && coordinates.trim()) {
+    const parts = coordinates.trim().split(/[ ,]+/).filter(Boolean);
+    if (parts.length >= 2) {
+      const first = Number(parts[0]);
+      const second = Number(parts[1]);
+      if (Number.isFinite(first) && Number.isFinite(second)) {
+        // VK raw payloads commonly encode geo.coordinates as "lon lat".
+        longitude = first;
+        latitude = second;
+      }
+    }
+  }
+
+  if (
+    (latitude === undefined || longitude === undefined) &&
+    typeof record.latitude === "number" &&
+    Number.isFinite(record.latitude) &&
+    typeof record.longitude === "number" &&
+    Number.isFinite(record.longitude)
+  ) {
+    latitude = record.latitude;
+    longitude = record.longitude;
+  }
+
+  if (latitude === undefined || longitude === undefined) {
+    return undefined;
+  }
+
+  const place =
+    record.place && typeof record.place === "object" && !Array.isArray(record.place)
+      ? (record.place as Record<string, unknown>)
+      : undefined;
+
+  return {
+    latitude,
+    longitude,
+    placeTitle: readString(place ?? {}, "title"),
+    city: readString(place ?? {}, "city"),
+  };
+}
+
+export function formatVkInboundGeoText(geo: VkInboundGeo | undefined): string {
+  if (!geo) {
+    return "";
+  }
+
+  const placeParts = [geo.placeTitle?.trim(), geo.city?.trim()].filter(
+    (entry): entry is string => Boolean(entry),
+  );
+  const placeText = placeParts.length > 0 ? ` (${placeParts.join(", ")})` : "";
+  return `[VK location] ${geo.latitude}, ${geo.longitude}${placeText}`;
+}
+
 export function resolveVkInboundMediaUrls(
   attachments: readonly VkInboundAttachment[] | undefined,
 ): string[] {
@@ -603,10 +677,12 @@ export function resolveVkInboundResolvedMediaTypes(
 export function resolveVkInboundBodyText(params: {
   text?: string | null;
   attachments?: readonly VkInboundAttachment[];
+  geo?: VkInboundGeo;
 }): string {
   const trimmedText = params.text?.trim() ?? "";
+  const geoText = formatVkInboundGeoText(params.geo);
   if (trimmedText) {
-    return trimmedText;
+    return geoText ? `${trimmedText}\n\n${geoText}` : trimmedText;
   }
 
   const mediaKinds = Array.from(
@@ -617,10 +693,11 @@ export function resolveVkInboundBodyText(params: {
     ),
   );
   if (mediaKinds.length === 0) {
-    return "";
+    return geoText;
   }
 
-  return `<media:${mediaKinds[0] ?? "attachment"}>`;
+  const mediaText = `<media:${mediaKinds[0] ?? "attachment"}>`;
+  return geoText ? `${mediaText}\n${geoText}` : mediaText;
 }
 
 function isHttpMediaUrl(value: string): boolean {

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -270,6 +270,7 @@ describe("message_new handler", () => {
     await getMessageHandler()(
       makeCtx({
         id: 99,
+        conversationMessageId: 42,
         peerId: 123_456,
         senderId: 555_000,
         text: "hi",
@@ -281,6 +282,7 @@ describe("message_new handler", () => {
     const { message } = mockHandleVkInbound.mock.calls[0][0];
     expect(message).toMatchObject({
       messageId: "99",
+      conversationMessageId: 42,
       peerId: 123_456,
       senderId: 555_000,
       text: "hi",
@@ -395,6 +397,7 @@ describe("message_new handler", () => {
     await getMessageHandler()(
       makeCtx({
         text: "",
+        hasGeo: true,
         geo: {
           coordinates: "37.815848 55.916704",
           place: {
@@ -433,7 +436,7 @@ describe("message_new handler", () => {
       ],
     });
 
-    await getMessageHandler()(makeCtx({ text: "" }));
+    await getMessageHandler()(makeCtx({ text: "", hasGeo: true }));
 
     const { message } = mockHandleVkInbound.mock.calls[0][0];
     expect(mockMessagesGetById).toHaveBeenCalledWith({ message_ids: 42 });
@@ -448,6 +451,27 @@ describe("message_new handler", () => {
       placeTitle: undefined,
       city: undefined,
     });
+  });
+
+  it("does not call geo enrichment APIs for ordinary text-only messages", async () => {
+    activeMonitor = startMonitor();
+    await flush();
+
+    await getMessageHandler()(makeCtx({ text: "just text", hasGeo: false, geo: undefined }));
+
+    expect(mockMessagesGetById).not.toHaveBeenCalled();
+    expect(mockMessagesGetByConversationMessageId).not.toHaveBeenCalled();
+    expect(mockMessagesGetHistory).not.toHaveBeenCalled();
+  });
+
+  it("preserves conversationMessageId for downstream status reactions", async () => {
+    activeMonitor = startMonitor();
+    await flush();
+
+    await getMessageHandler()(makeCtx({ conversationMessageId: 777 }));
+
+    const { message } = mockHandleVkInbound.mock.calls[0][0];
+    expect(message.conversationMessageId).toBe(777);
   });
 
   it("records inbound activity before dispatching", async () => {

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -49,6 +49,15 @@ const mockGroupsGetById = vi.hoisted(() =>
 const mockGroupsGetLongPollServer = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ server: "lp.vk.com", key: "abc", ts: 1 }),
 );
+const mockMessagesGetById = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ items: [] }),
+);
+const mockMessagesGetByConversationMessageId = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ items: [] }),
+);
+const mockMessagesGetHistory = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ items: [] }),
+);
 
 vi.mock("vk-io", () => ({
   // Must use a regular function (not an arrow) so `new VK(...)` works.
@@ -58,6 +67,11 @@ vi.mock("vk-io", () => ({
         groups: {
           getById: mockGroupsGetById,
           getLongPollServer: mockGroupsGetLongPollServer,
+        },
+        messages: {
+          getById: mockMessagesGetById,
+          getByConversationMessageId: mockMessagesGetByConversationMessageId,
+          getHistory: mockMessagesGetHistory,
         },
       },
       updates: {
@@ -146,6 +160,9 @@ beforeEach(() => {
   mockGroupsGetLongPollServer
     .mockReset()
     .mockResolvedValue({ server: "lp.vk.com", key: "abc", ts: 1 });
+  mockMessagesGetById.mockReset().mockResolvedValue({ items: [] });
+  mockMessagesGetByConversationMessageId.mockReset().mockResolvedValue({ items: [] });
+  mockMessagesGetHistory.mockReset().mockResolvedValue({ items: [] });
   mockHandleVkInbound.mockReset().mockResolvedValue(undefined);
   mockPrimeVkGroupId.mockReset();
   setVkRuntime(makeVkRuntime());
@@ -369,6 +386,68 @@ describe("message_new handler", () => {
 
     const { message } = mockHandleVkInbound.mock.calls[0][0];
     expect(message.text).toBe("");
+  });
+
+  it("keeps location-only messages visible via geo fallback", async () => {
+    activeMonitor = startMonitor();
+    await flush();
+
+    await getMessageHandler()(
+      makeCtx({
+        text: "",
+        geo: {
+          coordinates: "37.815848 55.916704",
+          place: {
+            title: "Королёв",
+            city: "Россия",
+          },
+        },
+      }),
+    );
+
+    const { message } = mockHandleVkInbound.mock.calls[0][0];
+    expect(message.text).toBe("[VK location] 55.916704, 37.815848 (Королёв, Россия)");
+    expect(message.geo).toEqual({
+      latitude: 55.916704,
+      longitude: 37.815848,
+      placeTitle: "Королёв",
+      city: "Россия",
+    });
+  });
+
+  it("fetches geo from messages.getHistory when context itself has no geo", async () => {
+    activeMonitor = startMonitor();
+    await flush();
+
+    mockMessagesGetById.mockResolvedValueOnce({ items: [] });
+    mockMessagesGetHistory.mockResolvedValueOnce({
+      items: [
+        {
+          id: 42,
+          from_id: 555_000,
+          text: "",
+          geo: {
+            coordinates: "37.815848 55.916704",
+          },
+        },
+      ],
+    });
+
+    await getMessageHandler()(makeCtx({ text: "" }));
+
+    const { message } = mockHandleVkInbound.mock.calls[0][0];
+    expect(mockMessagesGetById).toHaveBeenCalledWith({ message_ids: 42 });
+    expect(mockMessagesGetHistory).toHaveBeenCalledWith({
+      peer_id: 555_000,
+      count: 10,
+    });
+    expect(message.text).toBe("[VK location] 55.916704, 37.815848");
+    expect(message.geo).toEqual({
+      latitude: 55.916704,
+      longitude: 37.815848,
+      placeTitle: undefined,
+      city: undefined,
+    });
   });
 
   it("records inbound activity before dispatching", async () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -53,6 +53,15 @@ function shouldEnrichFromApi(context: {
   return !isVkContextHydrated(context) || resolveVkContextGeo(context) == null;
 }
 
+function hasVkGeoSignal(context: {
+  hasGeo?: unknown;
+  geo?: unknown;
+  message?: { geo?: unknown } | undefined;
+  payload?: { message?: { geo?: unknown } | undefined } | undefined;
+}): boolean {
+  return Boolean(context.hasGeo || resolveVkContextGeo(context));
+}
+
 function resolveVkMessagePayload(rawPayload: unknown): unknown {
   if (typeof rawPayload !== "string") {
     return rawPayload;
@@ -231,8 +240,9 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
       return;
     }
 
+    const geoSignalPresent = hasVkGeoSignal(context);
     let fetchedMessage: VkApiMessagePayload | undefined;
-    if (shouldEnrichFromApi(context)) {
+    if (geoSignalPresent && shouldEnrichFromApi(context)) {
       fetchedMessage = await fetchVkApiMessagePayload({
         vk,
         context: {
@@ -254,7 +264,7 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
       }
     }
 
-    if (!fetchedMessage?.geo) {
+    if (geoSignalPresent && !fetchedMessage?.geo) {
       const historyMessage = await fetchVkApiMessagePayloadFromHistory({
         vk,
         context: {
@@ -309,6 +319,14 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
 
     const message: VkInboundMessage = {
       messageId: String(context.id),
+      conversationMessageId:
+        typeof context.conversationMessageId === "number" &&
+        Number.isFinite(context.conversationMessageId)
+          ? context.conversationMessageId
+          : typeof fetchedMessage?.conversation_message_id === "number" &&
+              Number.isFinite(fetchedMessage.conversation_message_id)
+            ? fetchedMessage.conversation_message_id
+            : undefined,
       peerId,
       senderId,
       text: visibleBody,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -4,6 +4,8 @@ import { resolveVkAccount } from "./accounts.js";
 import { handleVkInbound } from "./inbound.js";
 import {
   extractVkInboundAttachments,
+  resolveVkInboundBodyText,
+  resolveVkInboundGeo,
   resolveVkInboundReplyContext,
 } from "./media.js";
 import { getVkRuntime } from "./runtime.js";
@@ -17,6 +19,137 @@ export type VkMonitorOptions = {
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
 };
+
+type VkApiMessagePayload = {
+  id?: number;
+  conversation_message_id?: number;
+  from_id?: number;
+  date?: number;
+  text?: string;
+  attachments?: unknown[];
+  geo?: unknown;
+  reply_message?: unknown;
+  payload?: unknown;
+};
+
+function resolveVkContextGeo(context: {
+  geo?: unknown;
+  message?: { geo?: unknown } | undefined;
+  payload?: { message?: { geo?: unknown } | undefined } | undefined;
+}): unknown {
+  return context.geo ?? context.message?.geo ?? context.payload?.message?.geo;
+}
+
+function isVkContextHydrated(context: { $filled?: unknown }): boolean {
+  return context.$filled === true;
+}
+
+function shouldEnrichFromApi(context: {
+  $filled?: unknown;
+  geo?: unknown;
+  message?: { geo?: unknown } | undefined;
+  payload?: { message?: { geo?: unknown } | undefined } | undefined;
+}): boolean {
+  return !isVkContextHydrated(context) || resolveVkContextGeo(context) == null;
+}
+
+function resolveVkMessagePayload(rawPayload: unknown): unknown {
+  if (typeof rawPayload !== "string") {
+    return rawPayload;
+  }
+  try {
+    return JSON.parse(rawPayload);
+  } catch {
+    return rawPayload;
+  }
+}
+
+async function fetchVkApiMessagePayload(params: {
+  vk: VK;
+  context: {
+    id: number;
+    peerId: number;
+    conversationMessageId: number;
+  };
+  runtime: RuntimeEnv;
+}): Promise<VkApiMessagePayload | undefined> {
+  try {
+    const response =
+      params.context.id !== 0
+        ? await params.vk.api.messages.getById({
+            message_ids: params.context.id,
+          })
+        : await params.vk.api.messages.getByConversationMessageId({
+            peer_id: params.context.peerId,
+            conversation_message_ids: params.context.conversationMessageId,
+          });
+    return response.items[0] as VkApiMessagePayload | undefined;
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    params.runtime.log?.(
+      `vk: direct API fetch failed for peerId=${params.context.peerId} messageId=${params.context.id}: ${errorMessage}`,
+    );
+    return undefined;
+  }
+}
+
+async function fetchVkApiMessagePayloadFromHistory(params: {
+  vk: VK;
+  context: {
+    id: number;
+    peerId: number;
+    conversationMessageId: number;
+    senderId?: number;
+    text?: string;
+    createdAt?: number;
+  };
+  runtime: RuntimeEnv;
+}): Promise<VkApiMessagePayload | undefined> {
+  try {
+    const response = await params.vk.api.messages.getHistory({
+      peer_id: params.context.peerId,
+      count: 10,
+    });
+    const items = response.items as VkApiMessagePayload[] | undefined;
+    if (!Array.isArray(items) || items.length === 0) {
+      return undefined;
+    }
+    const normalizedText = params.context.text?.trim();
+    return items.find((item) => {
+      if (typeof item !== "object" || item == null) {
+        return false;
+      }
+      if (item.id === params.context.id && params.context.id !== 0) {
+        return true;
+      }
+      if (item.conversation_message_id === params.context.conversationMessageId) {
+        return true;
+      }
+      if (
+        normalizedText &&
+        item.text?.trim() === normalizedText &&
+        item.from_id === params.context.senderId
+      ) {
+        return true;
+      }
+      if (
+        typeof item.date === "number" &&
+        typeof params.context.createdAt === "number" &&
+        Math.abs(item.date - params.context.createdAt) <= 120 &&
+        item.from_id === params.context.senderId
+      ) {
+        return true;
+      }
+      return false;
+    });
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    params.runtime.log?.(
+      `vk: history API fetch failed for peerId=${params.context.peerId} messageId=${params.context.id}: ${errorMessage}`,
+    );
+    return undefined;
+  }
+}
 
 /**
  * Check whether the Bots Long Poll API is accessible for this token.
@@ -98,12 +231,77 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
       return;
     }
 
+    let fetchedMessage: VkApiMessagePayload | undefined;
+    if (shouldEnrichFromApi(context)) {
+      fetchedMessage = await fetchVkApiMessagePayload({
+        vk,
+        context: {
+          id: context.id,
+          peerId: context.peerId,
+          conversationMessageId: context.conversationMessageId,
+        },
+        runtime: opts.runtime,
+      });
+      if (!fetchedMessage) {
+        try {
+          await context.loadMessagePayload?.();
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          opts.runtime.log?.(
+            `vk: failed to hydrate message payload for peerId=${context.peerId} messageId=${context.id}: ${errorMessage}`,
+          );
+        }
+      }
+    }
+
+    if (!fetchedMessage?.geo) {
+      const historyMessage = await fetchVkApiMessagePayloadFromHistory({
+        vk,
+        context: {
+          id: context.id,
+          peerId: context.peerId,
+          conversationMessageId: context.conversationMessageId,
+          senderId: context.senderId,
+          text: context.text,
+          createdAt: context.createdAt,
+        },
+        runtime: opts.runtime,
+      });
+      if (historyMessage) {
+        fetchedMessage = {
+          ...historyMessage,
+          ...fetchedMessage,
+          geo: fetchedMessage?.geo ?? historyMessage.geo,
+          attachments: fetchedMessage?.attachments ?? historyMessage.attachments,
+          payload: fetchedMessage?.payload ?? historyMessage.payload,
+          reply_message: fetchedMessage?.reply_message ?? historyMessage.reply_message,
+          text: fetchedMessage?.text ?? historyMessage.text,
+        };
+      }
+    }
+
     const peerId = context.peerId;
     const senderId = context.senderId;
-    const text = context.text ?? "";
+    const text = fetchedMessage?.text ?? context.text ?? "";
     const isGroup = peerId >= 2_000_000_000;
-    const attachments = extractVkInboundAttachments(context.attachments);
-    const replyContext = resolveVkInboundReplyContext(context.replyMessage);
+    const attachments = extractVkInboundAttachments(fetchedMessage?.attachments ?? context.attachments);
+    const rawGeo = fetchedMessage?.geo ?? resolveVkContextGeo(context);
+    const geo = resolveVkInboundGeo(rawGeo);
+    opts.runtime.log?.(
+      `vk: inbound message_new peerId=${peerId} messageId=${context.id} hydrated=${isVkContextHydrated(
+        context,
+      )} hasGeo=${Boolean(context.hasGeo || rawGeo || fetchedMessage?.geo)} resolvedGeo=${Boolean(
+        geo,
+      )} textLen=${text.length} attachments=${attachments.length}`,
+    );
+    const visibleBody = resolveVkInboundBodyText({
+      text,
+      attachments,
+      geo,
+    });
+    const replyContext = resolveVkInboundReplyContext(
+      fetchedMessage?.reply_message ?? context.replyMessage,
+    );
     const createdAtSeconds =
       typeof context.createdAt === "number" && Number.isFinite(context.createdAt)
         ? context.createdAt
@@ -111,20 +309,23 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
 
     const message: VkInboundMessage = {
       messageId: String(context.id),
-      conversationMessageId:
-        typeof context.conversationMessageId === "number" && Number.isFinite(context.conversationMessageId)
-          ? context.conversationMessageId
-          : undefined,
       peerId,
       senderId,
-      text,
+      text: visibleBody,
       timestamp: createdAtSeconds ? createdAtSeconds * 1000 : Date.now(),
       isGroup,
-      messagePayload: context.messagePayload,
+      messagePayload: resolveVkMessagePayload(fetchedMessage?.payload ?? context.messagePayload),
+      geo,
       attachments,
       replyToMessageId: replyContext.replyToMessageId,
       replyToText: replyContext.replyToText,
     };
+
+    if ((context.hasGeo || rawGeo || fetchedMessage?.geo) && !geo) {
+      opts.runtime.log?.(
+        `vk: geo present but unresolved for peerId=${peerId} messageId=${context.id}; rawGeo=${JSON.stringify(rawGeo)}`,
+      );
+    }
 
     core.channel.activity.record({
       channel: "vk",

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,9 +49,17 @@ export type VkInboundMessage = {
   timestamp: number;
   isGroup: boolean;
   messagePayload?: unknown;
+  geo?: VkInboundGeo;
   attachments?: VkInboundAttachment[];
   replyToMessageId?: string;
   replyToText?: string;
+};
+
+export type VkInboundGeo = {
+  latitude: number;
+  longitude: number;
+  placeTitle?: string;
+  city?: string;
 };
 
 export type VkButtonStyle = "primary" | "secondary" | "success" | "danger";


### PR DESCRIPTION
## Summary
- preserve VK location-only inbound messages instead of dropping them as empty bodies
- resolve geo from multiple VK payload layers and parse both object and `"lon lat"` string coordinate formats
- enrich missing geo via VK API/history fallback and add focused tests for geo parsing and monitor handling

## Problem
In production, VK messages sent as native location attachments were reaching OpenClaw without a usable visible body. Two cases were affected:
- a message containing only a VK location could be ignored because the effective inbound body became empty
- a message with text plus VK location lost the location context before it reached the agent

This happened because `vk-io` payload hydration is inconsistent for `geo`: sometimes it is present in raw message payloads, sometimes only recoverable via follow-up API calls, and raw coordinates can arrive as a string in `lon lat` order.

## What changed
- added `VkInboundGeo` to the inbound message model
- taught media helpers to parse and format VK geo payloads
- made inbound body generation include a `[VK location] lat, lon` line when geo is present
- taught the monitor to look for geo in multiple context layers and to fall back to `messages.getById` / `messages.getByConversationMessageId` / `messages.getHistory` when needed
- added tests for geo parsing, location-only message rendering, and history-based geo recovery

## Testing
- `npm test`
