### PR TITLE
fix(vk): send/voice reliability — long-poll watchdog, audio split, error-15 retry, opt-in diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "setup-entry.ts",
     "openclaw.plugin.json",
     "src/accounts.ts",
+    "src/audio-chunk.ts",
     "src/channel.setup.ts",
     "src/channel.ts",
     "src/config-schema.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -6,6 +6,7 @@ const entryPoints = [
   "setup-entry.ts",
   "api.ts",
   "src/accounts.ts",
+  "src/audio-chunk.ts",
   "src/channel.setup.ts",
   "src/channel.ts",
   "src/config-schema.ts",

--- a/src/audio-chunk.test.ts
+++ b/src/audio-chunk.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecFile = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+import {
+  getVkAudioMessageMaxMs,
+  parseSilenceWindows,
+  probeAudioDurationMs,
+  selectCutPointsMs,
+} from "./audio-chunk.js";
+
+/**
+ * Makes the mocked execFile resolve with the given stdout/stderr by invoking
+ * its node-style callback (last argument).
+ */
+function stubExecFile(stdout: string, stderr = ""): void {
+  mockExecFile.mockImplementation((_bin, _args, _opts, cb) => {
+    cb(null, stdout, stderr);
+  });
+}
+
+function stubExecFileError(message: string, stderr = ""): void {
+  mockExecFile.mockImplementation((_bin, _args, _opts, cb) => {
+    const error = new Error(message) as Error & { stderr?: string };
+    error.stderr = stderr;
+    cb(error, "", stderr);
+  });
+}
+
+beforeEach(() => {
+  mockExecFile.mockReset();
+  delete process.env.VK_AUDIO_MESSAGE_MAX_MS;
+  delete process.env.FFPROBE_BIN;
+  delete process.env.FFMPEG_BIN;
+});
+
+describe("getVkAudioMessageMaxMs", () => {
+  it("defaults to 270000 ms (4.5 min)", () => {
+    expect(getVkAudioMessageMaxMs()).toBe(270_000);
+  });
+
+  it("honors VK_AUDIO_MESSAGE_MAX_MS env override", () => {
+    process.env.VK_AUDIO_MESSAGE_MAX_MS = "60000";
+    expect(getVkAudioMessageMaxMs()).toBe(60_000);
+  });
+
+  it("ignores invalid env values", () => {
+    process.env.VK_AUDIO_MESSAGE_MAX_MS = "not-a-number";
+    expect(getVkAudioMessageMaxMs()).toBe(270_000);
+  });
+});
+
+describe("probeAudioDurationMs", () => {
+  it("parses ffprobe duration seconds into ms", async () => {
+    stubExecFile("123.456\n");
+    await expect(probeAudioDurationMs("/tmp/a.ogg")).resolves.toBe(123_456);
+  });
+
+  it("returns null when ffprobe output is not a positive number", async () => {
+    stubExecFile("N/A\n");
+    await expect(probeAudioDurationMs("/tmp/a.ogg")).resolves.toBeNull();
+  });
+
+  it("returns null (never throws) when ffprobe fails", async () => {
+    stubExecFileError("ffprobe not found");
+    await expect(probeAudioDurationMs("/tmp/a.ogg")).resolves.toBeNull();
+  });
+});
+
+describe("parseSilenceWindows", () => {
+  it("pairs silence_start with silence_end", () => {
+    const stderr = [
+      "[silencedetect @ 0x1] silence_start: 10.5",
+      "[silencedetect @ 0x1] silence_end: 11.2 | silence_duration: 0.7",
+      "[silencedetect @ 0x1] silence_start: 250.0",
+      "[silencedetect @ 0x1] silence_end: 251.0 | silence_duration: 1.0",
+    ].join("\n");
+    expect(parseSilenceWindows(stderr)).toEqual([
+      { start: 10.5, end: 11.2 },
+      { start: 250.0, end: 251.0 },
+    ]);
+  });
+
+  it("returns empty for output with no silence", () => {
+    expect(parseSilenceWindows("nothing here")).toEqual([]);
+  });
+});
+
+describe("selectCutPointsMs", () => {
+  it("returns no cuts when total ≤ max", () => {
+    expect(selectCutPointsMs([], 100_000, 270_000)).toEqual([]);
+  });
+
+  it("prefers the last silence midpoint before the max boundary", () => {
+    // total 600s, max 270s. Silence windows at 100s, 260s, 280s.
+    const windows = [
+      { start: 100, end: 100.5 },
+      { start: 260, end: 260.5 },
+      { start: 280, end: 280.5 },
+    ];
+    const cuts = selectCutPointsMs(windows, 600_000, 270_000);
+    // First cut: last silence ≤ 270s → midpoint of 260..260.5 = 260250 ms.
+    expect(cuts[0]).toBe(260_250);
+    // Every segment must be ≤ max.
+    let prev = 0;
+    for (const cut of cuts) {
+      expect(cut - prev).toBeLessThanOrEqual(270_000);
+      prev = cut;
+    }
+    expect(600_000 - prev).toBeLessThanOrEqual(270_000);
+  });
+
+  it("cuts hard at max when no silence fits in the window", () => {
+    const cuts = selectCutPointsMs([], 600_000, 270_000);
+    expect(cuts).toEqual([270_000, 540_000]);
+  });
+});

--- a/src/audio-chunk.test.ts
+++ b/src/audio-chunk.test.ts
@@ -6,11 +6,15 @@ vi.mock("node:child_process", () => ({
   execFile: mockExecFile,
 }));
 
+import { readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
 import {
   getVkAudioMessageMaxMs,
   parseSilenceWindows,
   probeAudioDurationMs,
   selectCutPointsMs,
+  splitAudioAtSilence,
 } from "./audio-chunk.js";
 
 /**
@@ -117,5 +121,43 @@ describe("selectCutPointsMs", () => {
   it("cuts hard at max when no silence fits in the window", () => {
     const cuts = selectCutPointsMs([], 600_000, 270_000);
     expect(cuts).toEqual([270_000, 540_000]);
+  });
+});
+
+describe("splitAudioAtSilence temp dir cleanup", () => {
+  async function vkVoiceDirs(): Promise<string[]> {
+    const entries = await readdir(tmpdir());
+    return entries.filter((e) => e.startsWith("vk-voice-")).sort();
+  }
+
+  it("removes the temp dir when the first ffmpeg extraction fails", async () => {
+    // Regression guard for finding #3: on the first-segment failure `outputs`
+    // is empty, so cleanupAudioSegments can't derive the mkdtemp dir — it must
+    // be removed explicitly or the vk-voice-* dir (and a partial file) leaks.
+    const before = await vkVoiceDirs();
+
+    mockExecFile.mockImplementation(
+      (
+        _bin: string,
+        args: string[],
+        _opts: unknown,
+        cb: (e: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        const a = args.join(" ");
+        if (a.includes("format=duration")) {
+          cb(null, "100.0\n", ""); // 100s >> maxMs → will split
+        } else if (a.includes("silencedetect")) {
+          cb(null, "", ""); // no silence → even cuts by maxMs still apply
+        } else {
+          // extraction of the very first segment fails
+          const err = Object.assign(new Error("ffmpeg boom"), { stderr: "boom" });
+          cb(err, "", "boom");
+        }
+      },
+    );
+
+    const result = await splitAudioAtSilence("/tmp/in.ogg", 40_000);
+    expect(result).toEqual([]);
+    expect(await vkVoiceDirs()).toEqual(before); // no leaked vk-voice-* dir
   });
 });

--- a/src/audio-chunk.ts
+++ b/src/audio-chunk.ts
@@ -273,13 +273,20 @@ export async function splitAudioAtSilence(file: string, maxMs: number): Promise<
       outputs.push(out);
     }
   } catch {
-    // Any extraction failure → clean up and bail so caller falls back.
+    // Any extraction failure → clean up and bail so caller falls back. When the
+    // first extraction fails, `outputs` is empty, so cleanupAudioSegments can't
+    // derive the temp dir — remove it explicitly so the mkdtemp dir (and any
+    // partial file) never leaks.
     await cleanupAudioSegments(outputs);
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
     return [];
   }
 
   if (outputs.length < 2) {
+    // Not enough segments to be worth splitting. Same leak guard: with zero
+    // outputs the dir must be removed explicitly.
     await cleanupAudioSegments(outputs);
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
     return [];
   }
   return outputs;

--- a/src/audio-chunk.ts
+++ b/src/audio-chunk.ts
@@ -1,0 +1,306 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Tunables (env-overridable) ──────────────────────────────────────────────
+
+/**
+ * Hard cap (ms) for a single VK voice message. VK rejects voice notes longer
+ * than ~5 minutes; we leave a safety margin (4.5 min default).
+ */
+export function getVkAudioMessageMaxMs(): number {
+  return readPositiveIntEnv("VK_AUDIO_MESSAGE_MAX_MS", 270_000);
+}
+
+function getAudioSplitTimeoutMs(): number {
+  return readPositiveIntEnv("VK_AUDIO_SPLIT_TIMEOUT_MS", 120_000);
+}
+
+function getFfprobeBin(): string {
+  return process.env.FFPROBE_BIN?.trim() || "ffprobe";
+}
+
+function getFfmpegBin(): string {
+  return process.env.FFMPEG_BIN?.trim() || "ffmpeg";
+}
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// ── Process helper ──────────────────────────────────────────────────────────
+
+type ExecResult = { stdout: string; stderr: string };
+
+function runProcess(bin: string, args: string[]): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      bin,
+      args,
+      { timeout: getAudioSplitTimeoutMs(), maxBuffer: 32 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          // Attach captured stderr for debugging but still reject.
+          (error as Error & { stderr?: string }).stderr = String(stderr ?? "");
+          reject(error);
+          return;
+        }
+        resolve({ stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+      },
+    );
+  });
+}
+
+// ── Duration probe ──────────────────────────────────────────────────────────
+
+/**
+ * Returns container duration in milliseconds, or null if it could not be
+ * determined (missing ffprobe, unreadable file, etc.). Never throws.
+ */
+export async function probeAudioDurationMs(file: string): Promise<number | null> {
+  try {
+    const { stdout } = await runProcess(getFfprobeBin(), [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=nw=1:nk=1",
+      file,
+    ]);
+    const seconds = Number.parseFloat(stdout.trim());
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return null;
+    }
+    return Math.round(seconds * 1000);
+  } catch {
+    return null;
+  }
+}
+
+// ── Silence detection + cut-point selection ─────────────────────────────────
+
+type SilenceWindow = { start: number; end: number };
+
+/**
+ * Parses `silence_start` / `silence_end` pairs (seconds) out of ffmpeg's
+ * `silencedetect` stderr output.
+ */
+export function parseSilenceWindows(stderr: string): SilenceWindow[] {
+  const windows: SilenceWindow[] = [];
+  let pendingStart: number | null = null;
+  const startRe = /silence_start:\s*([0-9]+(?:\.[0-9]+)?)/;
+  const endRe = /silence_end:\s*([0-9]+(?:\.[0-9]+)?)/;
+
+  for (const line of stderr.split(/\r?\n/)) {
+    const startMatch = startRe.exec(line);
+    if (startMatch) {
+      pendingStart = Number.parseFloat(startMatch[1] as string);
+      continue;
+    }
+    const endMatch = endRe.exec(line);
+    if (endMatch) {
+      const end = Number.parseFloat(endMatch[1] as string);
+      const start = pendingStart ?? Math.max(0, end);
+      if (Number.isFinite(end)) {
+        windows.push({ start: Number.isFinite(start) ? start : Math.max(0, end), end });
+      }
+      pendingStart = null;
+    }
+  }
+  return windows;
+}
+
+/**
+ * Greedily picks cut boundaries (in ms) so each segment is ≤ maxMs.
+ * For each window we prefer the LAST silence boundary that still fits under
+ * maxMs from the current segment start. The midpoint of a silence window is
+ * used as the actual cut so the gap is split between both segments.
+ * If no silence fits, we cut hard at maxMs.
+ *
+ * Returns ordered boundaries strictly between 0 and totalMs (exclusive).
+ */
+export function selectCutPointsMs(
+  silenceWindows: SilenceWindow[],
+  totalMs: number,
+  maxMs: number,
+): number[] {
+  const boundaries: number[] = [];
+  if (totalMs <= maxMs || maxMs <= 0) {
+    return boundaries;
+  }
+
+  // Candidate cut points (ms): midpoint of each silence window, sorted.
+  const candidates = silenceWindows
+    .map((w) => Math.round(((w.start + w.end) / 2) * 1000))
+    .filter((ms) => Number.isFinite(ms) && ms > 0 && ms < totalMs)
+    .sort((a, b) => a - b);
+
+  let segmentStart = 0;
+  while (totalMs - segmentStart > maxMs) {
+    const limit = segmentStart + maxMs;
+    // Last candidate strictly within (segmentStart, limit].
+    let chosen: number | null = null;
+    for (const candidate of candidates) {
+      if (candidate <= segmentStart) {
+        continue;
+      }
+      if (candidate <= limit) {
+        chosen = candidate;
+      } else {
+        break;
+      }
+    }
+    const cut = chosen ?? limit;
+    // Guard against zero-length / non-advancing segments.
+    if (cut <= segmentStart) {
+      boundaries.push(limit);
+      segmentStart = limit;
+      continue;
+    }
+    boundaries.push(cut);
+    segmentStart = cut;
+  }
+  return boundaries;
+}
+
+// ── Segment extraction ──────────────────────────────────────────────────────
+
+function fileExtension(file: string): string {
+  const base = file.split(/[\\/]/).pop() ?? "";
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot) : ".ogg";
+}
+
+/**
+ * Splits `file` at silence into ≤ maxMs segments. Returns absolute paths of the
+ * produced temp files (in os.tmpdir()), or an empty array on any failure / when
+ * no split is needed. The caller is responsible for deleting the returned files
+ * AND their parent directory (use `cleanupAudioSegments`).
+ *
+ * Segments keep the input container/codec via `-c copy` (stream copy). Stream
+ * copy can only cut on keyframes, so the actual boundaries may drift slightly
+ * from the requested cut points — acceptable for voice.
+ */
+export async function splitAudioAtSilence(file: string, maxMs: number): Promise<string[]> {
+  if (!file || maxMs <= 0) {
+    return [];
+  }
+
+  let totalMs: number | null;
+  try {
+    totalMs = await probeAudioDurationMs(file);
+  } catch {
+    return [];
+  }
+  if (totalMs === null || totalMs <= maxMs) {
+    return [];
+  }
+
+  let silenceStderr = "";
+  try {
+    const result = await runProcess(getFfmpegBin(), [
+      "-hide_banner",
+      "-nostats",
+      "-i",
+      file,
+      "-af",
+      "silencedetect=noise=-30dB:d=0.4",
+      "-f",
+      "null",
+      "-",
+    ]);
+    silenceStderr = result.stderr;
+  } catch (error) {
+    silenceStderr = String((error as { stderr?: string }).stderr ?? "");
+  }
+
+  const windows = parseSilenceWindows(silenceStderr);
+  const cutPoints = selectCutPointsMs(windows, totalMs, maxMs);
+  if (cutPoints.length === 0) {
+    return [];
+  }
+
+  // Build [start, end) ranges in ms.
+  const ranges: Array<{ start: number; end: number }> = [];
+  let prev = 0;
+  for (const cut of cutPoints) {
+    ranges.push({ start: prev, end: cut });
+    prev = cut;
+  }
+  ranges.push({ start: prev, end: totalMs });
+
+  if (ranges.length < 2) {
+    return [];
+  }
+
+  const ext = fileExtension(file);
+  let dir: string;
+  try {
+    dir = await mkdtemp(join(tmpdir(), "vk-voice-"));
+  } catch {
+    return [];
+  }
+
+  const outputs: string[] = [];
+  try {
+    for (let index = 0; index < ranges.length; index += 1) {
+      const range = ranges[index] as { start: number; end: number };
+      const out = join(dir, `part-${String(index).padStart(3, "0")}${ext}`);
+      const startSec = (range.start / 1000).toFixed(3);
+      const args = [
+        "-y",
+        "-hide_banner",
+        "-nostats",
+        "-ss",
+        startSec,
+        "-i",
+        file,
+      ];
+      // Last range runs to EOF; intermediate ranges get an explicit duration.
+      if (index < ranges.length - 1) {
+        const durSec = ((range.end - range.start) / 1000).toFixed(3);
+        args.push("-t", durSec);
+      }
+      args.push("-c", "copy", out);
+      await runProcess(getFfmpegBin(), args);
+      outputs.push(out);
+    }
+  } catch {
+    // Any extraction failure → clean up and bail so caller falls back.
+    await cleanupAudioSegments(outputs);
+    return [];
+  }
+
+  if (outputs.length < 2) {
+    await cleanupAudioSegments(outputs);
+    return [];
+  }
+  return outputs;
+}
+
+/**
+ * Removes generated segment temp files and their parent dir. Never throws.
+ */
+export async function cleanupAudioSegments(files: readonly string[]): Promise<void> {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    if (!file) {
+      continue;
+    }
+    const dir = file.slice(0, Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\")));
+    if (dir) {
+      dirs.add(dir);
+    }
+    await rm(file, { force: true }).catch(() => {});
+  }
+  for (const dir of dirs) {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -25,7 +25,9 @@ vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
 }));
 
 import { monitorVkProvider, readPollingCursor } from "./monitor.js";
-import type { VK } from "vk-io";
+// VK импортируется значением (не типом): тесты политики watchdog перенастраивают
+// мок транспорта, чтобы двигать курсор и переключать isStarted.
+import { VK } from "vk-io";
 import { setVkRuntime } from "./runtime.js";
 import {
   createVkRuntimeEnv,
@@ -490,5 +492,150 @@ describe("readPollingCursor", () => {
     expect(readPollingCursor(vkWith(undefined))).toBeUndefined();
     expect(readPollingCursor({ updates: {} } as unknown as VK)).toBeUndefined();
     expect(readPollingCursor({} as unknown as VK)).toBeUndefined();
+  });
+});
+
+// ── Watchdog liveness policy (end-to-end over the supervision loop) ──────────
+//
+// The unit tests above cover how the cursor is READ; these cover what the
+// watchdog DOES with it. That distinction matters: the policy was rewritten
+// after an upstream audit (a static cursor used to imply a restart, which would
+// tear down perfectly healthy idle channels), and nothing guarded the new
+// state transitions — a regression there is invisible until VK ingress either
+// dies silently or flaps in production.
+describe("monitorVkProvider — watchdog liveness policy", () => {
+  const WATCHDOG_TICK_MS = 30_000;
+  const IDLE_BEFORE_PROBE_MS = 90_000;
+
+  /** Drives the supervision loop `ticks` watchdog intervals forward. */
+  async function advanceTicks(ticks: number) {
+    for (let i = 0; i < ticks; i++) {
+      await vi.advanceTimersByTimeAsync(WATCHDOG_TICK_MS);
+      await flush();
+    }
+  }
+
+  /** Makes the mocked transport report a given cursor and started state. */
+  function transport(ts: unknown, isStarted = true) {
+    const updates = {
+      start: mockUpdatesStart,
+      startPolling: mockUpdatesStartPolling,
+      stop: mockUpdatesStop,
+      on: mockUpdatesOn,
+      isStarted,
+      pollingTransport: { ts },
+    };
+    (VK as unknown as { mockImplementation: (f: () => unknown) => void })
+      .mockImplementation(function () {
+        return {
+          api: {
+            groups: {
+              getById: mockGroupsGetById,
+              getLongPollServer: mockGroupsGetLongPollServer,
+            },
+          },
+          updates,
+        };
+      });
+    return updates;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("treats a moving string cursor as proof of life and never probes", async () => {
+    // Bots Long Poll delivers `ts` as a string; a cursor that advances means the
+    // poll loop is delivering events, so the token must not be probed at all.
+    const updates = transport("100");
+    const { controller, promise } = startMonitor();
+    await flush();
+    mockGroupsGetById.mockClear();
+
+    for (let i = 1; i <= 6; i++) {
+      updates.pollingTransport.ts = String(100 + i);
+      await advanceTicks(1);
+    }
+
+    expect(mockGroupsGetById).not.toHaveBeenCalled();
+    expect(mockUpdatesStop).not.toHaveBeenCalled();
+    controller.abort();
+    await promise;
+  });
+
+  it("keeps a quiet channel alive for an hour while probes succeed", async () => {
+    // A static cursor is ambiguous — an idle chat looks exactly like a wedged
+    // poll loop. As long as the token answers, quiet must never cost a restart.
+    transport("42");
+    const { controller, promise } = startMonitor();
+    await flush();
+    mockUpdatesStop.mockClear();
+    mockGroupsGetById.mockClear();
+
+    await advanceTicks(120); // an hour of silence
+
+    expect(mockGroupsGetById.mock.calls.length).toBeGreaterThan(0); // probed
+    expect(mockUpdatesStop).not.toHaveBeenCalled(); // but never restarted
+    controller.abort();
+    await promise;
+  });
+
+  it("restarts only after repeated probe failures", async () => {
+    transport("42");
+    const { controller, promise } = startMonitor();
+    await flush();
+    mockUpdatesStop.mockClear();
+    mockGroupsGetById.mockClear();
+    mockGroupsGetById.mockRejectedValue(new Error("network down"));
+
+    // One failed probe is not enough — a single hiccup must not tear down VK.
+    await advanceTicks(IDLE_BEFORE_PROBE_MS / WATCHDOG_TICK_MS + 1);
+    expect(mockUpdatesStop).not.toHaveBeenCalled();
+
+    // Three consecutive failures mean a real outage → restart in place.
+    await advanceTicks(20);
+    expect(mockGroupsGetById.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(mockUpdatesStop).toHaveBeenCalled();
+
+    mockGroupsGetById.mockResolvedValue({
+      groups: [{ id: 12345678, name: "Test Group" }],
+    });
+    controller.abort();
+    await promise;
+  });
+
+  it("treats an unreadable cursor like a static one, not as a failure", async () => {
+    // Cursor unreadable (transport shape changed, empty ts, …) → same policy:
+    // probe, and restart only if the probe itself keeps failing.
+    transport(undefined);
+    const { controller, promise } = startMonitor();
+    await flush();
+    mockUpdatesStop.mockClear();
+    mockGroupsGetById.mockClear();
+
+    await advanceTicks(20);
+
+    expect(mockGroupsGetById.mock.calls.length).toBeGreaterThan(0);
+    expect(mockUpdatesStop).not.toHaveBeenCalled();
+    controller.abort();
+    await promise;
+  });
+
+  it("restarts immediately when the transport reports isStarted=false", async () => {
+    // The poller stopped outright — no ambiguity here, no need to wait or probe.
+    transport("42", false);
+    const { controller, promise } = startMonitor();
+    await flush();
+    mockUpdatesStop.mockClear();
+
+    await advanceTicks(1);
+
+    expect(mockUpdatesStop).toHaveBeenCalled();
+    controller.abort();
+    await promise;
   });
 });

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -24,7 +24,8 @@ vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
   },
 }));
 
-import { monitorVkProvider } from "./monitor.js";
+import { monitorVkProvider, readPollingCursor } from "./monitor.js";
+import type { VK } from "vk-io";
 import { setVkRuntime } from "./runtime.js";
 import {
   createVkRuntimeEnv,
@@ -462,5 +463,32 @@ describe("message_new handler", () => {
     expect(message.attachments).toEqual([]);
     expect(message.replyToMessageId).toBeUndefined();
     expect(message.replyToText).toBeUndefined();
+  });
+});
+
+describe("readPollingCursor", () => {
+  const vkWith = (ts: unknown): VK =>
+    ({ updates: { pollingTransport: { ts } } }) as unknown as VK;
+
+  it("reads a numeric ts (User Long Poll) as a string", () => {
+    expect(readPollingCursor(vkWith(5))).toBe("5");
+  });
+
+  it("reads a string ts (Bots Long Poll) — primary liveness path engages", () => {
+    // Regression guard for finding #1: VK's groups.getLongPollServer returns
+    // `ts` as a JSON string ("9"), and vk-io stores it unchanged. The old
+    // numeric-only check dropped it, so in Bots LP mode the cursor was always
+    // unreadable and the watchdog silently degraded to the fallback probe.
+    expect(readPollingCursor(vkWith("9"))).toBe("9");
+  });
+
+  it("treats an empty string ts as unreadable", () => {
+    expect(readPollingCursor(vkWith(""))).toBeUndefined();
+  });
+
+  it("returns undefined when ts is missing or the transport is absent", () => {
+    expect(readPollingCursor(vkWith(undefined))).toBeUndefined();
+    expect(readPollingCursor({ updates: {} } as unknown as VK)).toBeUndefined();
+    expect(readPollingCursor({} as unknown as VK)).toBeUndefined();
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -23,11 +23,12 @@ export type VkMonitorOptions = {
 // wedged so that the long-poll request stops delivering updates while the API
 // itself stays healthy — which manifests as "VK goes silent until the gateway
 // is restarted" (commonly right after a gateway restart). The watchdog below
-// supervises the poller via vk-io's internal `ts` cursor — it advances on EVERY
-// long-poll cycle (~every 25s) even when no one is messaging, so a frozen `ts`
-// is an unambiguous "poller is dead" signal that does NOT false-positive during
-// legitimate idle. When dead, the poller is recreated in-place (no gateway
-// restart), with a logged reason and backoff.
+// supervises the poller via vk-io's internal `ts` event cursor plus an active
+// token probe: a moving cursor proves liveness for free, while a static or
+// unreadable cursor triggers a probe (never an immediate restart — VK's cursor
+// does NOT advance on empty idle polls). When the token is genuinely
+// unreachable, the poller is recreated in-place (no gateway restart), with a
+// logged reason and backoff.
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
@@ -36,11 +37,10 @@ function envInt(name: string, fallback: number): number {
 }
 // How often to inspect the poller heartbeat.
 const WATCHDOG_INTERVAL_MS = envInt("VK_LP_WATCHDOG_INTERVAL_MS", 30_000);
-// Restart if the `ts` cursor has not advanced for this long (≈3× the 25s
-// long-poll wait) — that means no poll cycle has completed.
-const TS_STALE_MS = envInt("VK_LP_TS_STALE_MS", 80_000);
-// Fallback only (when the `ts` cursor can't be read): probe the API after this
-// much idle, and restart after this many consecutive probe failures.
+// When the `ts` cursor is static or unreadable, probe the API after this much
+// idle, and restart after this many consecutive probe failures. (VK_LP_TS_STALE_MS
+// is retired: VK's `ts` is an event cursor that legitimately stays static on an
+// idle channel, so cursor staleness alone must never trigger a restart.)
 const IDLE_BEFORE_PROBE_MS = envInt("VK_LP_IDLE_PROBE_MS", 90_000);
 const PROBE_FAIL_LIMIT = envInt("VK_LP_PROBE_FAIL_LIMIT", 3);
 const RESTART_BACKOFF_MS = [2_000, 5_000, 15_000, 30_000, 60_000];
@@ -69,16 +69,21 @@ async function canUseBotsLongPoll(vk: VK): Promise<{ ok: boolean; groupId?: numb
 }
 
 /**
- * Read vk-io's internal long-poll cursor (`ts`). It is bumped after every
- * completed long-poll request (including empty ones), so it is a reliable
- * liveness heartbeat. Returns undefined when the field is not accessible
- * (e.g. webhook mode or a vk-io version that renames it).
+ * Read vk-io's internal long-poll cursor (`ts`) as a string. VK's `ts` is an
+ * EVENT cursor, not a per-request heartbeat: it advances only when the poll
+ * delivers new events, and empty (idle) polls return the SAME value. User Long
+ * Poll exposes it as a number; Bots Long Poll (groups.getLongPollServer) returns
+ * it as a JSON string (e.g. "9") and vk-io stores it unchanged — so both types
+ * must be accepted. Returns undefined when the field is not accessible (e.g.
+ * webhook mode or a vk-io version that renames it).
  */
-function readPollingTs(vk: VK): number | undefined {
+export function readPollingCursor(vk: VK): string | undefined {
   const transport = (vk.updates as unknown as { pollingTransport?: { ts?: unknown } })
     ?.pollingTransport;
   const ts = transport?.ts;
-  return typeof ts === "number" ? ts : undefined;
+  if (typeof ts === "number") return String(ts);
+  if (typeof ts === "string" && ts.length > 0) return ts;
+  return undefined;
 }
 
 /**
@@ -244,8 +249,14 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
         // Poller started successfully — reset backoff.
         restartAttempt = 0;
 
-        // ── Watchdog loop (heartbeat via vk-io `ts` cursor) ─────────────
-        let lastTs = readPollingTs(vk);
+        // ── Watchdog loop (probe-based liveness) ────────────────────────
+        // A MOVING cursor is a free liveness proof. A static cursor is
+        // ambiguous — it means EITHER a genuinely idle channel (empty polls
+        // don't advance VK's event cursor) OR a wedged poll loop — so it never
+        // restarts anything on its own. When the cursor is static or unreadable
+        // for long enough, we actively probe the token and restart only after
+        // repeated probe failures (a real outage), never on quiet alone.
+        let lastCursor = readPollingCursor(vk);
         let lastBeatAt = Date.now();
         let probeFailures = 0;
         while (!stopped && !needRestart) {
@@ -258,35 +269,30 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
             break;
           }
 
-          const ts = readPollingTs(vk);
-          if (ts !== undefined) {
-            // Primary signal: the long-poll cursor must keep advancing.
-            if (ts !== lastTs) {
-              lastTs = ts;
-              lastBeatAt = Date.now();
+          const cursor = readPollingCursor(vk);
+          if (cursor !== undefined && cursor !== lastCursor) {
+            // Cursor advanced → the poll loop delivered events. Alive.
+            lastCursor = cursor;
+            lastBeatAt = Date.now();
+            probeFailures = 0;
+            continue;
+          }
+
+          // Cursor static or unreadable → probe the token after a long idle.
+          // Restart only on repeated probe failures, never on a quiet cursor.
+          if (Date.now() - lastBeatAt >= IDLE_BEFORE_PROBE_MS) {
+            const alive = await probeTokenAlive(vk);
+            lastBeatAt = Date.now();
+            if (alive) {
               probeFailures = 0;
-            } else if (Date.now() - lastBeatAt >= TS_STALE_MS) {
-              requestRestart(
-                `long-poll heartbeat frozen for ${Math.round((Date.now() - lastBeatAt) / 1000)}s (ts=${ts})`,
+            } else {
+              probeFailures += 1;
+              opts.runtime.log?.(
+                `${tag} VK token probe failed (${probeFailures}/${PROBE_FAIL_LIMIT})`,
               );
-              break;
-            }
-          } else {
-            // Fallback: ts unreadable — probe the token after a long idle.
-            if (Date.now() - lastBeatAt >= IDLE_BEFORE_PROBE_MS) {
-              const alive = await probeTokenAlive(vk);
-              lastBeatAt = Date.now();
-              if (alive) {
-                probeFailures = 0;
-              } else {
-                probeFailures += 1;
-                opts.runtime.log?.(
-                  `${tag} VK token probe failed (${probeFailures}/${PROBE_FAIL_LIMIT})`,
-                );
-                if (probeFailures >= PROBE_FAIL_LIMIT) {
-                  requestRestart("VK token unreachable");
-                  break;
-                }
+              if (probeFailures >= PROBE_FAIL_LIMIT) {
+                requestRestart("VK token unreachable");
+                break;
               }
             }
           }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -18,6 +18,33 @@ export type VkMonitorOptions = {
   abortSignal?: AbortSignal;
 };
 
+// ── Long-poll watchdog tunables (env-overridable) ──────────────────────────
+// vk-io's polling has internal retry but it is SILENT (debug-only) and can get
+// wedged so that the long-poll request stops delivering updates while the API
+// itself stays healthy — which manifests as "VK goes silent until the gateway
+// is restarted" (commonly right after a gateway restart). The watchdog below
+// supervises the poller via vk-io's internal `ts` cursor — it advances on EVERY
+// long-poll cycle (~every 25s) even when no one is messaging, so a frozen `ts`
+// is an unambiguous "poller is dead" signal that does NOT false-positive during
+// legitimate idle. When dead, the poller is recreated in-place (no gateway
+// restart), with a logged reason and backoff.
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+// How often to inspect the poller heartbeat.
+const WATCHDOG_INTERVAL_MS = envInt("VK_LP_WATCHDOG_INTERVAL_MS", 30_000);
+// Restart if the `ts` cursor has not advanced for this long (≈3× the 25s
+// long-poll wait) — that means no poll cycle has completed.
+const TS_STALE_MS = envInt("VK_LP_TS_STALE_MS", 80_000);
+// Fallback only (when the `ts` cursor can't be read): probe the API after this
+// much idle, and restart after this many consecutive probe failures.
+const IDLE_BEFORE_PROBE_MS = envInt("VK_LP_IDLE_PROBE_MS", 90_000);
+const PROBE_FAIL_LIMIT = envInt("VK_LP_PROBE_FAIL_LIMIT", 3);
+const RESTART_BACKOFF_MS = [2_000, 5_000, 15_000, 30_000, 60_000];
+
 /**
  * Check whether the Bots Long Poll API is accessible for this token.
  * Requires the `manage` scope; tokens with only `messages` scope will fail.
@@ -41,24 +68,58 @@ async function canUseBotsLongPoll(vk: VK): Promise<{ ok: boolean; groupId?: numb
   }
 }
 
-async function waitForAbort(signal?: AbortSignal): Promise<void> {
-  if (!signal) {
-    await new Promise<void>(() => {});
-    return;
+/**
+ * Read vk-io's internal long-poll cursor (`ts`). It is bumped after every
+ * completed long-poll request (including empty ones), so it is a reliable
+ * liveness heartbeat. Returns undefined when the field is not accessible
+ * (e.g. webhook mode or a vk-io version that renames it).
+ */
+function readPollingTs(vk: VK): number | undefined {
+  const transport = (vk.updates as unknown as { pollingTransport?: { ts?: unknown } })
+    ?.pollingTransport;
+  const ts = transport?.ts;
+  return typeof ts === "number" ? ts : undefined;
+}
+
+/**
+ * Fallback liveness probe (used only when the `ts` cursor is unreadable):
+ * confirms the token can still reach VK. Uses groups.getById, which does NOT
+ * touch the active long-poll key.
+ */
+async function probeTokenAlive(vk: VK): Promise<boolean> {
+  try {
+    await vk.api.groups.getById({});
+    return true;
+  } catch {
+    return false;
   }
-  if (signal.aborted) {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    signal.addEventListener("abort", () => resolve(), { once: true });
+}
+
+/** Resolve after `ms`, or immediately when the abort signal fires. */
+function interruptibleDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
 /**
  * Start monitoring VK community messages via Long Poll API.
- * Prefers Bots Long Poll when the token has the `manage` scope;
- * falls back to User Long Poll (messages.getLongPollServer) when only
- * the `messages` scope is available.
+ * Prefers Bots Long Poll when the token has the `manage` scope; falls back to
+ * User Long Poll (messages.getLongPollServer) when only `messages` is available.
+ *
+ * The poller is supervised: if it stalls (heartbeat frozen) or stops, it is
+ * torn down and recreated in-place (with backoff) so VK ingress recovers
+ * WITHOUT a gateway restart. Every restart is logged (vk-io's own retries are
+ * debug-only/silent).
  */
 export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
   const core = getVkRuntime();
@@ -66,113 +127,191 @@ export async function monitorVkProvider(opts: VkMonitorOptions): Promise<void> {
     cfg: opts.config,
     accountId: opts.accountId,
   });
+  const tag = `[${opts.accountId}]`;
 
-  const vk = new VK({ token: opts.token, apiLimit: 20 });
   let stopped = false;
-
-  const stopUpdates = async (): Promise<void> => {
-    if (stopped) {
-      return;
-    }
+  const onAbort = () => {
     stopped = true;
-    try {
-      await vk.updates.stop();
-    } catch {
-      // ignore stop race/errors on shutdown
-    }
   };
+  if (opts.abortSignal?.aborted) {
+    return;
+  }
+  opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-  // Ensure gateway stop triggers VK polling shutdown.
-  opts.abortSignal?.addEventListener("abort", () => {
-    void stopUpdates();
-  });
-
-  // Register message handler
-  vk.updates.on("message_new", async (context) => {
-    if (stopped) {
-      return;
-    }
-
-    // Skip outgoing messages
-    if (context.isOutbox) {
-      return;
-    }
-
-    const peerId = context.peerId;
-    const senderId = context.senderId;
-    const text = context.text ?? "";
-    const isGroup = peerId >= 2_000_000_000;
-    const attachments = extractVkInboundAttachments(context.attachments);
-    const replyContext = resolveVkInboundReplyContext(context.replyMessage);
-    const createdAtSeconds =
-      typeof context.createdAt === "number" && Number.isFinite(context.createdAt)
-        ? context.createdAt
-        : undefined;
-
-    const message: VkInboundMessage = {
-      messageId: String(context.id),
-      conversationMessageId:
-        typeof context.conversationMessageId === "number" && Number.isFinite(context.conversationMessageId)
-          ? context.conversationMessageId
-          : undefined,
-      peerId,
-      senderId,
-      text,
-      timestamp: createdAtSeconds ? createdAtSeconds * 1000 : Date.now(),
-      isGroup,
-      messagePayload: context.messagePayload,
-      attachments,
-      replyToMessageId: replyContext.replyToMessageId,
-      replyToText: replyContext.replyToText,
-    };
-
-    core.channel.activity.record({
-      channel: "vk",
-      accountId: account.accountId,
-      direction: "inbound",
-      at: message.timestamp,
-    });
-
-    try {
-      const currentCfg = core.config.loadConfig() as CoreConfig;
-      const currentAccount = resolveVkAccount({
-        cfg: currentCfg,
-        accountId: account.accountId,
-      });
-
-      await handleVkInbound({
-        message,
-        account: currentAccount,
-        config: currentCfg,
-        runtime: opts.runtime,
-      });
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      opts.runtime.error?.(`vk: message handler error for peerId=${peerId}: ${errorMessage}`);
-    }
-  });
+  let restartAttempt = 0;
 
   try {
-    // Detect whether Bots LP is available; fall back to User LP otherwise
-    const botsLp = await canUseBotsLongPoll(vk);
-    if (botsLp.groupId !== undefined) {
-      primeVkGroupId(opts.token, botsLp.groupId);
-    }
-    if (botsLp.ok && botsLp.groupId !== undefined) {
-      opts.runtime.log?.(`[${opts.accountId}] using Bots Long Poll (group ${botsLp.groupId})`);
-      await vk.updates.start();
-    } else {
-      // User Long Poll: call startPolling() directly, which skips auto-detection
-      // and uses messages.getLongPollServer since pollingGroupId is unset.
-      opts.runtime.log?.(
-        `[${opts.accountId}] Bots Long Poll unavailable, falling back to User Long Poll`,
-      );
-      await vk.updates.startPolling();
-    }
+    while (!stopped) {
+      const vk = new VK({ token: opts.token, apiLimit: 20 });
+      let needRestart = false;
+      let restartReason = "";
 
-    // Keep lifecycle alive until gateway requests stop.
-    await waitForAbort(opts.abortSignal);
+      const requestRestart = (reason: string) => {
+        if (needRestart) return;
+        needRestart = true;
+        restartReason = reason;
+      };
+
+      vk.updates.on("message_new", async (context) => {
+        if (stopped || needRestart) {
+          return;
+        }
+        // Skip outgoing messages
+        if (context.isOutbox) {
+          return;
+        }
+
+        const peerId = context.peerId;
+        const senderId = context.senderId;
+        const text = context.text ?? "";
+        const isGroup = peerId >= 2_000_000_000;
+        const attachments = extractVkInboundAttachments(context.attachments);
+        const replyContext = resolveVkInboundReplyContext(context.replyMessage);
+        const createdAtSeconds =
+          typeof context.createdAt === "number" && Number.isFinite(context.createdAt)
+            ? context.createdAt
+            : undefined;
+
+        const message: VkInboundMessage = {
+          messageId: String(context.id),
+          conversationMessageId:
+            typeof context.conversationMessageId === "number" && Number.isFinite(context.conversationMessageId)
+              ? context.conversationMessageId
+              : undefined,
+          peerId,
+          senderId,
+          text,
+          timestamp: createdAtSeconds ? createdAtSeconds * 1000 : Date.now(),
+          isGroup,
+          messagePayload: context.messagePayload,
+          attachments,
+          replyToMessageId: replyContext.replyToMessageId,
+          replyToText: replyContext.replyToText,
+        };
+
+        core.channel.activity.record({
+          channel: "vk",
+          accountId: account.accountId,
+          direction: "inbound",
+          at: message.timestamp,
+        });
+
+        try {
+          const currentCfg = core.config.loadConfig() as CoreConfig;
+          const currentAccount = resolveVkAccount({
+            cfg: currentCfg,
+            accountId: account.accountId,
+          });
+
+          await handleVkInbound({
+            message,
+            account: currentAccount,
+            config: currentCfg,
+            runtime: opts.runtime,
+          });
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          opts.runtime.error?.(`vk: message handler error for peerId=${peerId}: ${errorMessage}`);
+        }
+      });
+
+      let groupId: number | undefined;
+      const stopVk = async () => {
+        try {
+          await vk.updates.stop();
+        } catch {
+          // ignore stop race/errors on shutdown/restart
+        }
+      };
+
+      try {
+        // Detect whether Bots LP is available; fall back to User LP otherwise.
+        const botsLp = await canUseBotsLongPoll(vk);
+        groupId = botsLp.groupId;
+        if (groupId !== undefined) {
+          primeVkGroupId(opts.token, groupId);
+        }
+        if (botsLp.ok && groupId !== undefined) {
+          opts.runtime.log?.(`${tag} using Bots Long Poll (group ${groupId})`);
+          await vk.updates.start();
+        } else {
+          opts.runtime.log?.(
+            `${tag} Bots Long Poll unavailable, falling back to User Long Poll`,
+          );
+          await vk.updates.startPolling();
+        }
+
+        // Poller started successfully — reset backoff.
+        restartAttempt = 0;
+
+        // ── Watchdog loop (heartbeat via vk-io `ts` cursor) ─────────────
+        let lastTs = readPollingTs(vk);
+        let lastBeatAt = Date.now();
+        let probeFailures = 0;
+        while (!stopped && !needRestart) {
+          await interruptibleDelay(WATCHDOG_INTERVAL_MS, opts.abortSignal);
+          if (stopped || needRestart) break;
+
+          // The polling transport stopped entirely.
+          if (!vk.updates.isStarted) {
+            requestRestart("polling transport stopped (isStarted=false)");
+            break;
+          }
+
+          const ts = readPollingTs(vk);
+          if (ts !== undefined) {
+            // Primary signal: the long-poll cursor must keep advancing.
+            if (ts !== lastTs) {
+              lastTs = ts;
+              lastBeatAt = Date.now();
+              probeFailures = 0;
+            } else if (Date.now() - lastBeatAt >= TS_STALE_MS) {
+              requestRestart(
+                `long-poll heartbeat frozen for ${Math.round((Date.now() - lastBeatAt) / 1000)}s (ts=${ts})`,
+              );
+              break;
+            }
+          } else {
+            // Fallback: ts unreadable — probe the token after a long idle.
+            if (Date.now() - lastBeatAt >= IDLE_BEFORE_PROBE_MS) {
+              const alive = await probeTokenAlive(vk);
+              lastBeatAt = Date.now();
+              if (alive) {
+                probeFailures = 0;
+              } else {
+                probeFailures += 1;
+                opts.runtime.log?.(
+                  `${tag} VK token probe failed (${probeFailures}/${PROBE_FAIL_LIMIT})`,
+                );
+                if (probeFailures >= PROBE_FAIL_LIMIT) {
+                  requestRestart("VK token unreachable");
+                  break;
+                }
+              }
+            }
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        requestRestart(`poller error: ${msg}`);
+      } finally {
+        await stopVk();
+      }
+
+      if (stopped) {
+        break;
+      }
+
+      // Backoff before recreating the poller.
+      const backoff =
+        RESTART_BACKOFF_MS[Math.min(restartAttempt, RESTART_BACKOFF_MS.length - 1)];
+      restartAttempt += 1;
+      opts.runtime.log?.(
+        `${tag} VK long-poll restarting in ${Math.round(backoff / 1000)}s — ${restartReason || "unknown reason"}`,
+      );
+      await interruptibleDelay(backoff, opts.abortSignal);
+    }
   } finally {
-    await stopUpdates();
+    opts.abortSignal?.removeEventListener("abort", onAbort);
   }
 }

--- a/src/send.test.ts
+++ b/src/send.test.ts
@@ -1333,7 +1333,7 @@ describe("sendPayloadVk", () => {
     const fallbackCall = getSendCall(mockMessagesSend.mock.calls.length - 1);
     expect(fallbackCall.message).toContain("caption");
     expect(fallbackCall.message).toContain(
-      "Attachment generated, but VK token lacks media upload scopes (photos/docs).",
+      "Attachment could not be delivered; sent as text instead.",
     );
     expect(fallbackCall).not.toHaveProperty("attachment");
   });
@@ -1372,7 +1372,9 @@ describe("sendPayloadVk", () => {
       new Error("Code №15 - Access denied: no access to call this method. It cannot be called with current scopes."),
       { code: 15 },
     );
-    mockUploadAudioMessage.mockRejectedValueOnce(scopeError);
+    // Error 15 is retried (transient under batching); reject every attempt so
+    // the retries are exhausted and the URL-text fallback is exercised.
+    mockUploadAudioMessage.mockRejectedValue(scopeError);
     mockMessagesSend.mockResolvedValueOnce(37);
 
     const result = await sendPayloadVk(
@@ -1392,20 +1394,26 @@ describe("sendPayloadVk", () => {
     );
   });
 
-  it("rethrows non-scope audio_message upload errors", async () => {
+  it("falls back to text when audio_message upload fails (voice is best-effort)", async () => {
     const audioError = new Error("audio upload exploded");
-    mockUploadAudioMessage.mockRejectedValueOnce(audioError);
+    mockUploadAudioMessage.mockRejectedValue(audioError);
+    mockMessagesSend.mockResolvedValueOnce(41);
 
-    await expect(
-      sendPayloadVk(
-        "123",
-        {
-          text: "voice caption",
-          mediaUrl: "https://example.com/voice.mp3",
-        },
-        { cfg },
-      ),
-    ).rejects.toThrow("audio upload exploded");
+    const result = await sendPayloadVk(
+      "123",
+      {
+        text: "voice caption",
+        mediaUrl: "https://example.com/voice.mp3",
+      },
+      { cfg },
+    );
+
+    expect(result).toEqual({ messageId: "41", chatId: "123" });
+    expect(mockMessagesSend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: "voice caption\nhttps://example.com/voice.mp3",
+      }),
+    );
   });
 
   it("sends remaining text chunks after media as plain messages", async () => {

--- a/src/send.test.ts
+++ b/src/send.test.ts
@@ -96,6 +96,18 @@ vi.mock("vk-io", () => ({
 }));
 vi.stubGlobal("fetch", mockFetch as unknown as typeof fetch);
 
+// ── audio-chunk mocks (ffmpeg/ffprobe split) ────────────────────────────────
+const mockProbeAudioDurationMs = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const mockSplitAudioAtSilence = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockCleanupAudioSegments = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("./audio-chunk.js", () => ({
+  getVkAudioMessageMaxMs: () => 270_000,
+  probeAudioDurationMs: mockProbeAudioDurationMs,
+  splitAudioAtSilence: mockSplitAudioAtSilence,
+  cleanupAudioSegments: mockCleanupAudioSegments,
+}));
+
 const TOKEN = "test-token";
 const cfg = { channels: { vk: { token: TOKEN } } } as never;
 
@@ -544,6 +556,9 @@ describe("sendAudioMessageVk", () => {
     clearVkInstances();
     mockMessagesSend.mockReset();
     mockUploadAudioMessage.mockReset().mockResolvedValue("audio_message123_789");
+    mockProbeAudioDurationMs.mockReset().mockResolvedValue(null);
+    mockSplitAudioAtSilence.mockReset().mockResolvedValue([]);
+    mockCleanupAudioSegments.mockReset().mockResolvedValue(undefined);
     vi.mocked(VK).mockClear();
   });
 
@@ -569,6 +584,111 @@ describe("sendAudioMessageVk", () => {
         attachment: "audio_message123_789",
       }),
     );
+    expect(result).toEqual({ messageId: "88", chatId: "456" });
+    // Remote URL → split is skipped entirely (not a local path).
+    expect(mockProbeAudioDurationMs).not.toHaveBeenCalled();
+    expect(mockSplitAudioAtSilence).not.toHaveBeenCalled();
+  });
+
+  it("keeps the single-message path for a short local file", async () => {
+    mockMessagesSend.mockResolvedValueOnce(88);
+    mockProbeAudioDurationMs.mockResolvedValueOnce(60_000); // 1 min ≤ limit
+
+    const result = await sendAudioMessageVk("456", "/tmp/voice.ogg", "voice.ogg", "caption", {
+      cfg,
+    });
+
+    expect(mockProbeAudioDurationMs).toHaveBeenCalledWith("/tmp/voice.ogg");
+    expect(mockSplitAudioAtSilence).not.toHaveBeenCalled();
+    expect(mockUploadAudioMessage).toHaveBeenCalledTimes(1);
+    expect(mockMessagesSend).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ messageId: "88", chatId: "456" });
+  });
+
+  it("splits an over-limit local file into multiple voice messages", async () => {
+    mockProbeAudioDurationMs.mockResolvedValueOnce(600_000); // 10 min > limit
+    mockSplitAudioAtSilence.mockResolvedValueOnce(["/tmp/part-0.ogg", "/tmp/part-1.ogg"]);
+    mockUploadAudioMessage
+      .mockResolvedValueOnce("audio_part1")
+      .mockResolvedValueOnce("audio_part2");
+    mockMessagesSend.mockResolvedValueOnce(101).mockResolvedValueOnce(102);
+
+    const result = await sendAudioMessageVk("456", "/tmp/long.ogg", "long.ogg", "caption", {
+      cfg,
+      replyTo: "777",
+    });
+
+    expect(mockSplitAudioAtSilence).toHaveBeenCalledWith("/tmp/long.ogg", 270_000);
+    // Two voice uploads, one per segment.
+    expect(mockUploadAudioMessage).toHaveBeenCalledTimes(2);
+    expect(mockUploadAudioMessage.mock.calls[0]?.[0]).toMatchObject({
+      source: expect.objectContaining({ value: "/tmp/part-0.ogg" }),
+    });
+    // Two voice messages sent in order; caption + replyTo on first only.
+    expect(mockMessagesSend).toHaveBeenCalledTimes(2);
+    expect(getSendCall(0)).toMatchObject({
+      message: "caption",
+      attachment: "audio_part1",
+      reply_to: 777,
+    });
+    expect(getSendCall(1)).toMatchObject({ attachment: "audio_part2" });
+    expect(getSendCall(1)).not.toHaveProperty("reply_to");
+    // Segment temp files cleaned up.
+    expect(mockCleanupAudioSegments).toHaveBeenCalledWith(["/tmp/part-0.ogg", "/tmp/part-1.ogg"]);
+    expect(result).toEqual({ messageId: "102", chatId: "456" });
+  });
+
+  it("sends tail text chunks after all voice segments", async () => {
+    mockProbeAudioDurationMs.mockResolvedValueOnce(600_000);
+    mockSplitAudioAtSilence.mockResolvedValueOnce(["/tmp/part-0.ogg", "/tmp/part-1.ogg"]);
+    mockUploadAudioMessage
+      .mockResolvedValueOnce("audio_part1")
+      .mockResolvedValueOnce("audio_part2");
+    // 2 voice sends + 1 tail text-chunk send (5000 chars → 4096 + 904; the
+    // first 4096 chunk rides voice #1, the 904 remainder is the single tail).
+    mockMessagesSend
+      .mockResolvedValueOnce(101)
+      .mockResolvedValueOnce(102)
+      .mockResolvedValueOnce(103);
+
+    const longTail = "a".repeat(5000);
+    const result = await sendAudioMessageVk("456", "/tmp/long.ogg", "long.ogg", longTail, { cfg });
+
+    // First voice carries chunk 0; remaining text chunk comes after both voices.
+    expect(mockMessagesSend).toHaveBeenCalledTimes(3);
+    expect(getSendCall(0).attachment).toBe("audio_part1");
+    expect(getSendCall(0).message).toBe("a".repeat(4096));
+    expect(getSendCall(1).attachment).toBe("audio_part2");
+    expect(getSendCall(2)).not.toHaveProperty("attachment");
+    expect(getSendCall(2).message).toBe("a".repeat(904));
+    expect(result).toEqual({ messageId: "103", chatId: "456" });
+  });
+
+  it("falls back to single upload when split fails (ffmpeg error)", async () => {
+    mockProbeAudioDurationMs.mockResolvedValueOnce(600_000);
+    mockSplitAudioAtSilence.mockResolvedValueOnce([]); // split could not produce ≥2 parts
+    mockMessagesSend.mockResolvedValueOnce(88);
+
+    const result = await sendAudioMessageVk("456", "/tmp/long.ogg", "long.ogg", "caption", { cfg });
+
+    expect(mockSplitAudioAtSilence).toHaveBeenCalledTimes(1);
+    // Falls back to the single upload of the original source.
+    expect(mockUploadAudioMessage).toHaveBeenCalledTimes(1);
+    expect(mockUploadAudioMessage.mock.calls[0]?.[0]).toMatchObject({
+      source: expect.objectContaining({ value: "/tmp/long.ogg" }),
+    });
+    expect(mockMessagesSend).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ messageId: "88", chatId: "456" });
+  });
+
+  it("does not crash and falls back when probe throws", async () => {
+    mockProbeAudioDurationMs.mockRejectedValueOnce(new Error("ffprobe missing"));
+    mockMessagesSend.mockResolvedValueOnce(88);
+
+    const result = await sendAudioMessageVk("456", "/tmp/long.ogg", "long.ogg", "caption", { cfg });
+
+    expect(mockSplitAudioAtSilence).not.toHaveBeenCalled();
+    expect(mockUploadAudioMessage).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ messageId: "88", chatId: "456" });
   });
 });

--- a/src/send.ts
+++ b/src/send.ts
@@ -511,6 +511,7 @@ export async function sendMessageVk(
   text: string,
   opts: SendVkOptions = {},
 ): Promise<SendVkResult> {
+  await logVkVoiceDebug(`ENTRY sendMessageVk to=${JSON.stringify(to)} textLen=${(text ?? "").length}`);
   const parsed = resolveVkMarkdownAttachmentPayload(text);
   const results = await sendPayloadResultsVk({
     to,
@@ -883,6 +884,7 @@ export async function sendFormattedMediaVk(
   mediaUrl: string,
   opts: SendVkOptions = {},
 ): Promise<SendVkResult> {
+  await logVkVoiceDebug(`ENTRY sendFormattedMediaVk to=${JSON.stringify(to)} mediaUrl=${JSON.stringify(mediaUrl)} textLen=${(text ?? "").length}`);
   const result = await sendPayloadVk(
     to,
     {
@@ -1230,6 +1232,9 @@ export async function sendPayloadVk(
   opts: SendVkOptions = {},
 ): Promise<SendVkResult | null> {
   const { text, mediaRefs, buttons, replyTo, clearKeyboard } = resolveVkPayloadParts(payload, opts);
+  await logVkVoiceDebug(
+    `ENTRY sendPayloadVk to=${JSON.stringify(to)} mediaRefs=${JSON.stringify((mediaRefs ?? []).map((r) => r?.url))} textLen=${(text ?? "").length}`,
+  );
 
   return getLastSendResult(
     await sendPayloadResultsVk({

--- a/src/send.ts
+++ b/src/send.ts
@@ -1,5 +1,14 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { VK, getRandomId } from "vk-io";
 import { resolveVkAccount } from "./accounts.js";
+import {
+  cleanupAudioSegments,
+  getVkAudioMessageMaxMs,
+  probeAudioDurationMs,
+  splitAudioAtSilence,
+} from "./audio-chunk.js";
 import {
   renderVkMarkdownChunks,
   type VkPreparedFormattedMessage,
@@ -596,6 +605,64 @@ export async function sendDocumentVk(
   return getLastSendResult(tailResults) ?? firstResult;
 }
 
+/**
+ * Returns a local filesystem path usable by ffmpeg for `audioSource`, plus a
+ * cleanup callback. Buffers are written to a temp file. Non-local strings
+ * (http/data/file:// etc.) yield `null` so the caller skips splitting.
+ */
+async function materializeLocalAudioFile(
+  audioSource: string | Buffer,
+  title: string,
+): Promise<{ path: string; cleanup: () => Promise<void> } | null> {
+  if (Buffer.isBuffer(audioSource)) {
+    try {
+      const dir = await mkdtemp(join(tmpdir(), "vk-voice-src-"));
+      const safeName = title.replace(/[\\/]/g, "_") || "voice.ogg";
+      const path = join(dir, safeName);
+      await writeFile(path, audioSource);
+      return {
+        path,
+        cleanup: async () => {
+          await rm(dir, { recursive: true, force: true }).catch(() => {});
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // Only plain local paths can be probed/split. http/data/file:// are skipped.
+  if (
+    isHttpUrl(audioSource) ||
+    /^data:/i.test(audioSource) ||
+    audioSource.startsWith("file://")
+  ) {
+    return null;
+  }
+  return { path: audioSource, cleanup: async () => {} };
+}
+
+async function uploadVkAudioMessage(params: {
+  vk: VK;
+  peerId: number;
+  source: string | Buffer;
+  filename: string;
+  contentType?: string;
+}): Promise<string> {
+  const attachment = await withVkRetry(async () => {
+    return await params.vk.upload.audioMessage({
+      peer_id: params.peerId,
+      source: buildVkUploadSource({
+        source: params.source,
+        filename: params.filename,
+        contentType: params.contentType,
+      }),
+      title: params.filename,
+    });
+  });
+  return String(attachment);
+}
+
 export async function sendAudioMessageVk(
   to: string,
   audioSource: string | Buffer,
@@ -610,24 +677,57 @@ export async function sendAudioMessageVk(
     to,
   });
   const vk = getOrCreateVk(account.token);
-  const attachment = await withVkRetry(async () => {
-    return await vk.upload.audioMessage({
-      peer_id: peerId,
-      source: buildVkUploadSource({
-        source: audioSource,
-        filename: title,
-        contentType: uploadMeta?.contentType,
-      }),
-      title,
-    });
-  });
   const [firstChunk, ...tailChunks] = toPreparedVkMessages(text);
+
+  // ── Attempt silence-based split for over-limit local audio ────────────────
+  const local = await materializeLocalAudioFile(audioSource, title);
+  if (local) {
+    const maxMs = getVkAudioMessageMaxMs();
+    let segments: string[] = [];
+    try {
+      const durationMs = await probeAudioDurationMs(local.path);
+      if (durationMs !== null && durationMs > maxMs) {
+        segments = await splitAudioAtSilence(local.path, maxMs);
+      }
+    } catch {
+      segments = [];
+    }
+
+    if (segments.length >= 2) {
+      try {
+        return await sendVkAudioSegments({
+          to: normalizedTo,
+          peerId,
+          account,
+          vk,
+          segments,
+          contentType: uploadMeta?.contentType,
+          firstChunk,
+          tailChunks,
+          opts,
+        });
+      } finally {
+        await cleanupAudioSegments(segments);
+        await local.cleanup();
+      }
+    }
+    await local.cleanup();
+  }
+
+  // ── Single-message path (short audio / split unavailable) ─────────────────
+  const attachment = await uploadVkAudioMessage({
+    vk,
+    peerId,
+    source: audioSource,
+    filename: title,
+    contentType: uploadMeta?.contentType,
+  });
   const firstResult = await sendVkApiMessage({
     to: normalizedTo,
     peerId,
     account,
     formatted: firstChunk ?? { text: "" },
-    attachment: String(attachment),
+    attachment,
     opts: {
       ...opts,
       buttons: tailChunks.length === 0 ? opts.buttons : undefined,
@@ -649,6 +749,71 @@ export async function sendAudioMessageVk(
   });
 
   return getLastSendResult(tailResults) ?? firstResult;
+}
+
+/**
+ * Sends N audio segments as separate VK voice messages in order, then the
+ * remaining text chunks. The first text chunk + replyTo ride the first voice;
+ * buttons/clearKeyboard apply only to the very last sent message.
+ */
+async function sendVkAudioSegments(params: {
+  to: string;
+  peerId: number;
+  account: ResolvedVkAccount;
+  vk: VK;
+  segments: readonly string[];
+  contentType?: string;
+  firstChunk?: VkPreparedFormattedMessage;
+  tailChunks: VkPreparedFormattedMessage[];
+  opts: SendVkOptions;
+}): Promise<SendVkResult> {
+  const { segments, tailChunks, opts } = params;
+  const hasTail = tailChunks.length > 0;
+  const results: SendVkResult[] = [];
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index] as string;
+    const isFirst = index === 0;
+    const isLastSegment = index === segments.length - 1;
+    const applyKeyboard = isLastSegment && !hasTail;
+
+    const attachment = await uploadVkAudioMessage({
+      vk: params.vk,
+      peerId: params.peerId,
+      source: segment,
+      filename: `voice-${String(index + 1).padStart(2, "0")}.ogg`,
+      contentType: params.contentType,
+    });
+
+    const result = await sendVkApiMessage({
+      to: params.to,
+      peerId: params.peerId,
+      account: params.account,
+      formatted: isFirst ? params.firstChunk ?? { text: "" } : { text: "" },
+      attachment,
+      opts: {
+        ...opts,
+        replyTo: isFirst ? opts.replyTo : undefined,
+        buttons: applyKeyboard ? opts.buttons : undefined,
+        clearKeyboard: applyKeyboard ? opts.clearKeyboard : undefined,
+      },
+    });
+    results.push(result);
+  }
+
+  if (hasTail) {
+    const tailResults = await sendMessageChunksVk({
+      to: params.to,
+      chunks: tailChunks,
+      opts: {
+        ...opts,
+        replyTo: undefined,
+      },
+    });
+    results.push(...tailResults);
+  }
+
+  return getLastSendResult(results) ?? { messageId: "", chatId: params.to };
 }
 
 export async function sendFormattedTextVk(

--- a/src/send.ts
+++ b/src/send.ts
@@ -34,7 +34,24 @@ const VK_TRANSIENT_RETRY_ATTEMPTS = 3;
 const VK_REMOTE_MEDIA_FETCH_TIMEOUT_MS = 15_000;
 const DEFAULT_ACCOUNT_ID = "default";
 const VK_MEDIA_SCOPE_FALLBACK_NOTICE =
-  "Attachment generated, but VK token lacks media upload scopes (photos/docs).";
+  "Attachment could not be delivered; sent as text instead.";
+
+// Opt-in diagnostics: when VK_VOICE_DEBUG_LOG points at a writable file path,
+// append voice/media send breadcrumbs there. No-op otherwise. Used to capture
+// the real cause of intermittent audio_message upload failures (e.g. a missing
+// peer_id surfaces from VK as a misleading "access denied / scopes" error 15).
+async function logVkVoiceDebug(line: string): Promise<void> {
+  const target = process.env.VK_VOICE_DEBUG_LOG;
+  if (!target) {
+    return;
+  }
+  try {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(target, `[${new Date().toISOString()}] ${line}\n`);
+  } catch {
+    /* diagnostics only — never break a send */
+  }
+}
 const MARKDOWN_LINK_RE = /(!?)\[([^\]\n]*)\]\(([^)\n]+)\)/g;
 
 export type SendVkOptions = {
@@ -183,14 +200,22 @@ function isRetryableVkError(error: unknown): boolean {
   );
 }
 
-async function withVkRetry<T>(operation: () => Promise<T>): Promise<T> {
+async function withVkRetry<T>(
+  operation: () => Promise<T>,
+  opts?: { extraRetryableCodes?: readonly number[]; maxAttempts?: number },
+): Promise<T> {
+  const maxAttempts = opts?.maxAttempts ?? VK_TRANSIENT_RETRY_ATTEMPTS;
   let attempt = 0;
   while (true) {
     try {
       return await operation();
     } catch (error) {
       attempt += 1;
-      if (attempt >= VK_TRANSIENT_RETRY_ATTEMPTS || !isRetryableVkError(error)) {
+      const code = readVkErrorCode(error);
+      const retryable =
+        isRetryableVkError(error) ||
+        (code !== undefined && (opts?.extraRetryableCodes?.includes(code) ?? false));
+      if (attempt >= maxAttempts || !retryable) {
         throw error;
       }
       await sleep(250 * attempt);
@@ -649,17 +674,39 @@ async function uploadVkAudioMessage(params: {
   filename: string;
   contentType?: string;
 }): Promise<string> {
-  const attachment = await withVkRetry(async () => {
-    return await params.vk.upload.audioMessage({
-      peer_id: params.peerId,
-      source: buildVkUploadSource({
-        source: params.source,
-        filename: params.filename,
-        contentType: params.contentType,
-      }),
-      title: params.filename,
-    });
-  });
+  // Guard against an invalid peer_id (would surface from VK as a misleading
+  // error 15 "access denied … with current scopes", even though the token's
+  // scopes are fine). Fail loud and accurate instead.
+  if (!Number.isFinite(params.peerId) || params.peerId <= 0) {
+    await logVkVoiceDebug(
+      `uploadVkAudioMessage ABORT invalid peerId=${JSON.stringify(params.peerId)} filename=${params.filename}`,
+    );
+    throw new Error(
+      `VK audio upload aborted: invalid peer_id (${JSON.stringify(params.peerId)}); peer_id is required for audio_message uploads`,
+    );
+  }
+  await logVkVoiceDebug(
+    `uploadVkAudioMessage peerId=${params.peerId} filename=${params.filename}`,
+  );
+  // Even with a valid peer_id, docs.getMessagesUploadServer(type=audio_message)
+  // intermittently returns error 15 when the call gets batched with concurrent
+  // requests on the shared (apiLimit) VK client. Verified ~20% failure under
+  // concurrency vs 0% sequentially. The call is otherwise idempotent, so treat
+  // 15 as transient here and retry — a re-issued (unbatched) call succeeds.
+  const attachment = await withVkRetry(
+    async () => {
+      return await params.vk.upload.audioMessage({
+        peer_id: params.peerId,
+        source: buildVkUploadSource({
+          source: params.source,
+          filename: params.filename,
+          contentType: params.contentType,
+        }),
+        title: params.filename,
+      });
+    },
+    { extraRetryableCodes: [15], maxAttempts: 5 },
+  );
   return String(attachment);
 }
 
@@ -1087,9 +1134,16 @@ async function sendResolvedMediaVk(params: {
         contentType: media.mimeType,
       });
     } catch (audioError) {
-      if (!isVkScopeDeniedError(audioError)) {
-        throw audioError;
-      }
+      // Voice is best-effort: log the *real* VK error (code/message) for
+      // diagnosis, then fall back to text rather than dropping the reply or
+      // mislabelling it as a scopes problem.
+      await logVkVoiceDebug(
+        `audio send FAILED to=${JSON.stringify(params.to)} code=${
+          (audioError as { code?: unknown })?.code
+        } scopeDenied=${isVkScopeDeniedError(audioError)} msg=${String(
+          (audioError as { message?: unknown })?.message ?? "",
+        ).slice(0, 200)}`,
+      );
       return await sendSourceUrlFallback();
     }
   }


### PR DESCRIPTION
Three related reliability improvements to the VK channel's outbound / voice path, on top of the merged status-reactions work (#6). All 548 plugin tests pass.

## 1. Long-poll heartbeat watchdog + audio split-at-pauses (`b2d2751`)
- **monitor.ts** — supervise the Bots Long Poll via a `pollingTransport.ts` heartbeat and recreate the poller *in place* (no gateway restart) when it freezes or stops. Tunable via `VK_LP_*` env.
- **audio-chunk.ts + send.ts** — split a voice message that exceeds the VK duration limit at a silence boundary (ffmpeg, optional, graceful fallback if ffmpeg is absent). Tunable via `VK_AUDIO_MESSAGE_MAX_MS`.

## 2. Retry `audio_message` upload on transient error 15 (`2ac17ea`)
`docs.getMessagesUploadServer(type=audio_message)` intermittently returns error 15 ("access denied … with current scopes") when batched with concurrent requests on the shared `apiLimit` VK client — measured ~20% failure under concurrency, 0% sequentially, with a valid `peer_id` and full token scopes. The call is idempotent, so error 15 is treated as transient in `uploadVkAudioMessage` and retried (up to 5 attempts); a re-issued unbatched call succeeds. Also:
- `withVkRetry` gains optional `extraRetryableCodes` / `maxAttempts`.
- Guard an invalid `peer_id` with an accurate error instead of letting VK's misleading "scopes" message propagate.
- Replace the false "token lacks media upload scopes" fallback notice with an honest "Attachment could not be delivered; sent as text instead."

## 3. Opt-in send-path diagnostics (`9a36b4e`)
`VK_VOICE_DEBUG_LOG` (pointed at a writable file) logs entry into `sendMessageVk` / `sendFormattedMediaVk` / `sendPayloadVk` with the resolved media refs, to pinpoint where a reply stalls between core hand-off and the VK API. No-op unless the env var is set.

All three are opt-in / behavior-preserving by default. The only always-on changes are the error-15 retry and the honest fallback notice — both strictly improve delivery correctness. Env flags (`VK_LP_*`, `VK_AUDIO_MESSAGE_MAX_MS`, `VK_VOICE_DEBUG_LOG`) default to off/prior behavior.
