### PR TITLE
Fix compatibility with OpenClaw 2026.8 plugin SDK

### DIFF
--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -29,30 +29,28 @@ vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-pairing", () => ({
-  createChannelPairingController: ({ core, channel, accountId }: Record<string, unknown>) => ({
-    readStoreForDmPolicy: () =>
-      (core as any).channel.pairing.readAllowFromStore({ channel, accountId }),
-    upsertPairingRequest: (params: Record<string, unknown>) =>
-      (core as any).channel.pairing.upsertPairingRequest({ ...params, accountId }),
-  }),
-}));
-
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
-  issuePairingChallenge: async ({
-    upsertPairingRequest,
-    sendPairingReply,
-    senderId,
-    channel,
-    onReplyError,
-  }: Record<string, any>) => {
-    const result = await upsertPairingRequest({ channel, id: senderId });
-    if (result.created && sendPairingReply) {
-      try {
-        await sendPairingReply("pairing-reply-text");
-      } catch (err) {
-        onReplyError?.(err);
+  createChannelPairingController: ({ core, channel, accountId }: Record<string, unknown>) => {
+    const upsertPairingRequest = (params: Record<string, unknown>) =>
+      (core as any).channel.pairing.upsertPairingRequest({ ...params, channel, accountId });
+    return {
+      readStoreForDmPolicy: () =>
+        (core as any).channel.pairing.readAllowFromStore({ channel, accountId }),
+      upsertPairingRequest,
+      issueChallenge: async ({
+        sendPairingReply,
+        senderId,
+        onReplyError,
+      }: Record<string, any>) => {
+        const result = await upsertPairingRequest({ id: senderId });
+        if (result.created && sendPairingReply) {
+          try {
+            await sendPairingReply("pairing-reply-text");
+          } catch (err) {
+            onReplyError?.(err);
+          }
+        }
       }
-    }
+    };
   },
 }));
 
@@ -94,6 +92,7 @@ vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
     clear: vi.fn().mockResolvedValue(undefined),
     restoreInitial: vi.fn().mockResolvedValue(undefined),
   })),
+  logTypingFailure: mockLogTypingFailure,
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-policy", () => ({
@@ -130,10 +129,9 @@ const mockCreateReplyPrefixOptions = vi.hoisted(() => vi.fn());
 const mockCreateTypingCallbacks = vi.hoisted(() => vi.fn());
 const mockLogTypingFailure = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/channel-reply-pipeline", () => ({
   createReplyPrefixOptions: mockCreateReplyPrefixOptions,
   createTypingCallbacks: mockCreateTypingCallbacks,
-  logTypingFailure: mockLogTypingFailure,
 }));
 
 // ── Internal module mocks ────────────────────────────────────────────────────

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1,5 +1,4 @@
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
-import { issuePairingChallenge } from "openclaw/plugin-sdk/conversation-runtime";
 import { logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
 import {
   readStoreAllowFromForDmPolicy,
@@ -8,8 +7,7 @@ import {
 import {
   createReplyPrefixOptions,
   createTypingCallbacks,
-  logTypingFailure,
-} from "openclaw/plugin-sdk/channel-runtime";
+} from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -31,7 +29,7 @@ import {
 import { getVkRuntime } from "./runtime.js";
 import { markMessageReadVk, sendPayloadVk, sendTypingVk } from "./send.js";
 import { createVkStatusReactionController } from "./reactions-controller.js";
-import { DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
+import { DEFAULT_TIMING, logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 import type { ResolvedVkAccount } from "./types.js";
 import type { CoreConfig, VkInboundMessage } from "./types.js";
@@ -200,12 +198,10 @@ export async function handleVkInbound(params: {
       });
       if (!dmAllowed.allowed) {
         if (dmPolicy === "pairing") {
-          await issuePairingChallenge({
-            channel: CHANNEL_ID,
+          await pairing.issueChallenge({
             senderId: senderDisplay,
             senderIdLine: `Your VK user id: ${senderDisplay}`,
             meta: {},
-            upsertPairingRequest: pairing.upsertPairingRequest,
             sendPairingReply: async (text) => {
               await deliverVkReply({
                 payload: { text },


### PR DESCRIPTION
## Summary

- replace the removed channel-runtime imports with the current channel-reply-pipeline and channel-feedback entrypoints
- use the account-scoped ChannelPairingController.issueChallenge() API instead of the removed standalone conversation-runtime helper
- update the inbound SDK mocks to exercise the new pairing contract

## Why

OpenClaw 2026.8.1 no longer exports openclaw/plugin-sdk/channel-runtime, and conversation-runtime no longer exports issuePairingChallenge. As a result, the published VK plugin fails during gateway startup before the channel can run.

The new pairing controller preserves the existing account scoping while keeping the same DM pairing behavior and error handling.

## Verification

- 
pm test — 532 tests passed
- 
pm run check:pack — package build and dry-run pack passed
- runtime smoke-tested against OpenClaw 2026.8.1: plugin loads without SDK import errors and VK long-poll startup proceeds
